### PR TITLE
fix(server): refactor hydration context to use existing global data.

### DIFF
--- a/packages/retend-server/source/client.js
+++ b/packages/retend-server/source/client.js
@@ -244,13 +244,14 @@ async function restoreContext(context, routerCreateFn) {
       console.error('Hydration error: ', error);
     });
 
-  const newGlobalData = new Map();
+  const hydratedGlobalData = getGlobalContext().globalData;
+
   setGlobalContext({
     mode: Modes.Interactive,
     window,
     teleportIdCounter: { value: 0 },
     consistentValues: new Map(),
-    globalData: newGlobalData,
+    globalData: hydratedGlobalData,
   });
 
   router.setWindow(window);


### PR DESCRIPTION
### **User description**
## Problem.

In production builds using Static Site Generation, components calling useScopeContext() would throw an error after hydration, claiming that no scope provider was found. This issue did not occur in development mode.


## Root Cause:

The bug originated in the hydrate function within `retend-server/client.js`. The hydration process correctly recreated the application state (including scopes) in a temporary VDOM context. However, upon completing the hydration of the DOM nodes, the logic would switch to the final interactive browser context by creating a new, empty globalData map. This action discarded the entire scope state that had just been carefully reconstructed, leading to the "provider not found" error when components in the interactive app tried to access their scope.
Development mode was unaffected because it runs as a standard Single-Page Application (SPA) with a single, persistent global context.


## Solution:

The fix is to ensure the globalData map is preserved across the context switch. After the VDOM-based hydration pass is complete, we now capture the globalData map (which contains the populated scope information) and reuse it for the final interactive context. This guarantees a seamless transfer of state, and useScopeContext now functions correctly in the fully hydrated application.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix hydration context to preserve global data

- Prevent scope provider errors after SSG hydration

- Ensure seamless state transfer from VDOM to interactive context


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VDOM Hydration"] --> B["Capture Global Data"]
  B --> C["Interactive Context"]
  C --> D["Preserved Scope State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.js</strong><dd><code>Preserve global data during hydration context switch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/retend-server/source/client.js

<ul><li>Replace new empty Map with existing hydratedGlobalData<br> <li> Capture globalData from current context before switching<br> <li> Preserve scope state across hydration context switch</ul>


</details>


  </td>
  <td><a href="https://github.com/resuite/retend/pull/27/files#diff-46a953d48e0b4cf6b29a9e8fa83f4583bf4d10290fbf0a375a801c3b71df27c0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

