### PR TITLE
Draft: the useSetupEffect() function.

### DIFF
--- a/packages/retend/source/library/for.js
+++ b/packages/retend/source/library/for.js
@@ -144,6 +144,7 @@ export function For(list, fn, options) {
     const newNodes = withScopeSnapshot(snapshot, () =>
       h(fn, new ArgumentList(parameters))
     );
+    snapshot.node.setup();
     const nodes = /** @type {ChildNodeLike[]} */ (
       Array.isArray(newNodes) ? newNodes : [newNodes]
     );
@@ -180,6 +181,7 @@ export function For(list, fn, options) {
         const newNodes = withScopeSnapshot(snapshot, () => {
           return h(fn, new ArgumentList(parameters));
         });
+        snapshot.node.setup(); // run new effects
         const nodes = /** @type {ChildNodeLike[]} */ (
           Array.isArray(newNodes) ? newNodes : [newNodes]
         );

--- a/packages/retend/source/library/for.js
+++ b/packages/retend/source/library/for.js
@@ -1,6 +1,7 @@
 /** @import { JSX } from '../jsx-runtime/types.ts' */
 /** @import * as VDom from '../v-dom/index.js' */
 /** @import { ReactiveCellFunction } from './utils.js' */
+/** @import { ScopeSnapshot } from './scope.js' */
 
 import { Cell } from '@adbl/cells';
 import { h } from './jsx.js';
@@ -55,7 +56,7 @@ import { createScopeSnapshot, withScopeSnapshot } from './scope.js';
  */
 export function For(list, fn, options) {
   /*** @type {(Node | VDom.VNode)[]} */
-  const initialSnapshot = [];
+  const initialResult = [];
   const { window } = getGlobalContext();
   const { onBeforeNodesMove, onBeforeNodeRemove, key } = options ?? {};
 
@@ -68,19 +69,19 @@ export function For(list, fn, options) {
     for (const item of list) {
       const nodes = h(fn, new ArgumentList([item, Cell.source(i), list]));
       if (Array.isArray(nodes)) {
-        initialSnapshot.push(...nodes);
+        initialResult.push(...nodes);
       } else {
-        initialSnapshot.push(nodes);
+        initialResult.push(nodes);
       }
       i++;
     }
-    return initialSnapshot;
+    return initialResult;
   }
 
   // -----------------------------------------------
   // REACTIVE LISTS
   // -----------------------------------------------
-  /** @type {Map<any, { index: Cell<number>,  nodes: ChildNodeLike[] }>} */
+  /** @type {Map<any, { index: Cell<number>,  nodes: ChildNodeLike[], snapshot: ScopeSnapshot }>} */
   let cacheFromLastRun = new Map();
   const autoKeys = new WeakMap();
   const [listStart, listEnd] = createCommentPair();
@@ -128,173 +129,187 @@ export function For(list, fn, options) {
   let i = 0;
   // We get a snapshot of all current scopes to reuse when new
   // component instances are created.
-  const scopeSnapshot = createScopeSnapshot();
+  const base = createScopeSnapshot();
 
   for (const item of list.get()) {
     const index = Cell.source(i);
     const parameters = [item, index, list];
-    const newNodes = h(fn, new ArgumentList(parameters));
+    // We have to split the snashot so that each For item render
+    // can have its own effect context without polluting the others.
+    /** @type {ScopeSnapshot} */
+    const snapshot = {
+      scopes: base.scopes,
+      node: base.node.fork(),
+    };
+    const newNodes = withScopeSnapshot(snapshot, () =>
+      h(fn, new ArgumentList(parameters))
+    );
     const nodes = /** @type {ChildNodeLike[]} */ (
       Array.isArray(newNodes) ? newNodes : [newNodes]
     );
     addHydrationUpgradeListeners(nodes);
-    initialSnapshot.push(...nodes);
+    initialResult.push(...nodes);
     const itemKey = retrieveOrSetItemKey(item, i);
-    cacheFromLastRun.set(itemKey, { index, nodes });
+    cacheFromLastRun.set(itemKey, { index, nodes, snapshot });
     i++;
   }
 
   /** @type {ReactiveCellFunction<any, ChildNodeLike | VDom.VComment>} */
   const reactToListChanges = function (newList) {
-    withScopeSnapshot(scopeSnapshot, () => {
-      const { window } = getGlobalContext();
-      isRunningInVDom = matchContext(window, Modes.VDom);
-      const newCache = new Map();
-      /** @type {Map<ChildNodeLike, { itemKey: any, lastItemLastNode: ChildNodeLike | null }>} */
-      const nodeLookAhead = new Map();
+    const { window } = getGlobalContext();
+    isRunningInVDom = matchContext(window, Modes.VDom);
+    const newCache = new Map();
+    /** @type {Map<ChildNodeLike, { itemKey: any, lastItemLastNode: ChildNodeLike | null }>} */
+    const nodeLookAhead = new Map();
 
-      let index = 0;
-      let lastItemLastNode = null;
-      for (const item of newList) {
-        const itemKey = retrieveOrSetItemKey(item, index);
-        const cachedResult = cacheFromLastRun.get(itemKey);
-        let firstNode = null;
-        let lastNode = null;
-        if (cachedResult === undefined) {
-          const i = Cell.source(index);
-          const parameters = [item, i, list];
-          const newNodes = h(fn, new ArgumentList(parameters));
-          const nodes = /** @type {ChildNodeLike[]} */ (
-            Array.isArray(newNodes) ? newNodes : [newNodes]
-          );
-          addHydrationUpgradeListeners(nodes);
-          newCache.set(itemKey, { nodes, index: i });
-          firstNode = nodes[0];
-          lastNode = nodes[nodes.length - 1];
-        } else {
-          /** @type {import('@adbl/cells').SourceCell<number>} */
-          (cachedResult.index).set(index);
-          newCache.set(itemKey, cachedResult);
-          const nodes = cachedResult.nodes;
-          firstNode = nodes[0];
-          lastNode = nodes[nodes.length - 1];
-        }
-        if (firstNode)
-          nodeLookAhead.set(firstNode, { itemKey, lastItemLastNode });
-        lastItemLastNode = lastNode;
-        index++;
+    let index = 0;
+    let lastItemLastNode = null;
+    for (const item of newList) {
+      const itemKey = retrieveOrSetItemKey(item, index);
+      const cachedResult = cacheFromLastRun.get(itemKey);
+      let firstNode = null;
+      let lastNode = null;
+      if (cachedResult === undefined) {
+        const i = Cell.source(index);
+        const parameters = [item, i, list];
+        /** @type {ScopeSnapshot} */
+        const snapshot = {
+          scopes: base.scopes,
+          node: base.node.fork(),
+        };
+        const newNodes = withScopeSnapshot(snapshot, () => {
+          return h(fn, new ArgumentList(parameters));
+        });
+        const nodes = /** @type {ChildNodeLike[]} */ (
+          Array.isArray(newNodes) ? newNodes : [newNodes]
+        );
+        addHydrationUpgradeListeners(nodes);
+        newCache.set(itemKey, { nodes, index: i, snapshot });
+        firstNode = nodes[0];
+        lastNode = nodes[nodes.length - 1];
+      } else {
+        /** @type {import('@adbl/cells').SourceCell<number>} */
+        (cachedResult.index).set(index);
+        newCache.set(itemKey, cachedResult);
+        const nodes = cachedResult.nodes;
+        firstNode = nodes[0];
+        lastNode = nodes[nodes.length - 1];
+      }
+      if (firstNode)
+        nodeLookAhead.set(firstNode, { itemKey, lastItemLastNode });
+      lastItemLastNode = lastNode;
+      index++;
+    }
+
+    // Removing Deleted Nodes:
+    //
+    // This pass is necessary to remove nodes in one go,
+    // rather than bubbling them to the end of the list.
+    //
+    // e.g. Consider a scenario where a list changes from [A, B, C, D, E] to [B, C, D, E]
+    // Ideal solution is a removeChild(A), but without this pass, what would happen is:
+    //  [A, B, C, D, E] -> [B, A, C, D, E]
+    //  [B, A, C, D, E] -> [B, C, A, D, E]
+    //  [B, C, A, D, E] -> [B, C, D, A, E]
+    //  [B, C, D, A, E] -> [B, C, D, E, A]
+    // before removing A, result in a removal and reinsertion of several unchanged nodes.
+    for (const [key, value] of cacheFromLastRun) {
+      if (newCache.has(key)) continue;
+      value.snapshot.node.dispose();
+      // There was a previous optimization to try and remove contiguous nodes
+      // at once with range.deleteContents(), but it was not worth it.
+      for (const node of value.nodes) {
+        onBeforeNodeRemove?.(node, value.index.get());
+        node.remove();
+      }
+    }
+
+    // deno-lint-ignore no-this-alias
+    let lastInserted = this;
+
+    // Reordering and Inserting New Nodes:
+    //
+    // This pass ensures nodes are in the correct order and new nodes are inserted.
+    // It compares each node's current position with the expected position after lastInserted,
+    // moving nodes only when necessary to maintain the correct sequence.
+    let i = 0;
+    const batchAdd = window.document.createDocumentFragment();
+    const batchAddLike = /** @type {*} */ (batchAdd);
+    for (const item of newList) {
+      /** @type {{ nodes: ChildNodeLike[] }} */ // Invariant: nodes is always defined.
+      const { nodes } = newCache.get(retrieveOrSetItemKey(item, i));
+      const isAlreadyInPosition = lastInserted.nextSibling === nodes[0];
+      if (isAlreadyInPosition) {
+        if (batchAdd.childNodes.length > 0) lastInserted.after(batchAddLike);
+        lastInserted = nodes[nodes.length - 1];
+        i++;
+        continue;
       }
 
-      // Removing Deleted Nodes:
+      // This branch takes care of the case where one item moves
+      // forward in the list, but until its correct position is reached, its nodes
+      // block other nodes from being correctly positioned, leading to cascading moves.
       //
-      // This pass is necessary to remove nodes in one go,
-      // rather than bubbling them to the end of the list.
-      //
-      // e.g. Consider a scenario where a list changes from [A, B, C, D, E] to [B, C, D, E]
-      // Ideal solution is a removeChild(A), but without this pass, what would happen is:
-      //  [A, B, C, D, E] -> [B, A, C, D, E]
-      //  [B, A, C, D, E] -> [B, C, A, D, E]
-      //  [B, C, A, D, E] -> [B, C, D, A, E]
-      //  [B, C, D, A, E] -> [B, C, D, E, A]
-      // before removing A, result in a removal and reinsertion of several unchanged nodes.
-      for (const [key, value] of cacheFromLastRun) {
-        if (newCache.has(key)) continue;
-        // There was a previous optimization to try and remove contiguous nodes
-        // at once with range.deleteContents(), but it was not worth it.
-        for (const node of value.nodes) {
-          onBeforeNodeRemove?.(node, value.index.get());
-          node.remove();
-        }
-      }
+      // Example: A list goes from [A, B, C, D, E] to [B, C, D, E, A], the simplest
+      // operation is to move A to the end of the list, but without this branch,
+      // the loop would have to:
+      // move B back, making [B, A, C, D, E]
+      // move C back, making [B, C, A, D, E]
+      // move D back, making [B, C, D, A, E]
+      // move E back, making [B, C, D, E, A]
+      const followingNode = lastInserted.nextSibling;
+      if (followingNode) {
+        const data = nodeLookAhead.get(followingNode);
+        if (data) {
+          const { itemKey, lastItemLastNode } = data;
+          const hasViableMoveAnchor =
+            lastItemLastNode?.parentNode &&
+            lastItemLastNode.parentNode !== batchAdd &&
+            lastItemLastNode.nextSibling !== followingNode &&
+            lastItemLastNode !== nodes[0];
+          if (hasViableMoveAnchor) {
+            const fullNodeSet = newCache.get(itemKey).nodes;
+            onBeforeNodesMove?.(nodes);
+            lastItemLastNode.after(...fullNodeSet);
 
-      // deno-lint-ignore no-this-alias
-      let lastInserted = this;
-
-      // Reordering and Inserting New Nodes:
-      //
-      // This pass ensures nodes are in the correct order and new nodes are inserted.
-      // It compares each node's current position with the expected position after lastInserted,
-      // moving nodes only when necessary to maintain the correct sequence.
-      let i = 0;
-      const batchAdd = window.document.createDocumentFragment();
-      const batchAddLike = /** @type {*} */ (batchAdd);
-      for (const item of newList) {
-        /** @type {{ nodes: ChildNodeLike[] }} */ // Invariant: nodes is always defined.
-        const { nodes } = newCache.get(retrieveOrSetItemKey(item, i));
-        const isAlreadyInPosition = lastInserted.nextSibling === nodes[0];
-        if (isAlreadyInPosition) {
-          if (batchAdd.childNodes.length > 0) lastInserted.after(batchAddLike);
-          lastInserted = nodes[nodes.length - 1];
-          i++;
-          continue;
-        }
-
-        // This branch takes care of the case where one item moves
-        // forward in the list, but until its correct position is reached, its nodes
-        // block other nodes from being correctly positioned, leading to cascading moves.
-        //
-        // Example: A list goes from [A, B, C, D, E] to [B, C, D, E, A], the simplest
-        // operation is to move A to the end of the list, but without this branch,
-        // the loop would have to:
-        // move B back, making [B, A, C, D, E]
-        // move C back, making [B, C, A, D, E]
-        // move D back, making [B, C, D, A, E]
-        // move E back, making [B, C, D, E, A]
-        const followingNode = lastInserted.nextSibling;
-        if (followingNode) {
-          const data = nodeLookAhead.get(followingNode);
-          if (data) {
-            const { itemKey, lastItemLastNode } = data;
-            const hasViableMoveAnchor =
-              lastItemLastNode?.parentNode &&
-              lastItemLastNode.parentNode !== batchAdd &&
-              lastItemLastNode.nextSibling !== followingNode &&
-              lastItemLastNode !== nodes[0];
-            if (hasViableMoveAnchor) {
-              const fullNodeSet = newCache.get(itemKey).nodes;
-              onBeforeNodesMove?.(nodes);
-              lastItemLastNode.after(...fullNodeSet);
-
-              // recheck sequential correctness.
-              const isAlreadyInPosition = lastInserted.nextSibling === nodes[0];
-              if (isAlreadyInPosition) {
-                if (batchAdd.childNodes.length)
-                  lastInserted.after(batchAddLike);
-                lastInserted = nodes[nodes.length - 1];
-                i++;
-                continue;
-              }
+            // recheck sequential correctness.
+            const isAlreadyInPosition = lastInserted.nextSibling === nodes[0];
+            if (isAlreadyInPosition) {
+              if (batchAdd.childNodes.length) lastInserted.after(batchAddLike);
+              lastInserted = nodes[nodes.length - 1];
+              i++;
+              continue;
             }
           }
         }
-
-        const isNewItemInstance = !nodes[0]?.parentNode;
-        if (isNewItemInstance) {
-          batchAddLike.append(...nodes);
-          i++;
-          continue;
-        }
-
-        if (batchAdd.childNodes.length === 0) {
-          onBeforeNodesMove?.(nodes);
-          lastInserted.after(.../** @type {*} */ (nodes));
-        } else {
-          const newPtr = /** @type {ChildNodeLike} */ (
-            batchAdd.childNodes[batchAdd.childNodes.length - 1]
-          );
-          lastInserted.after(batchAddLike);
-          onBeforeNodesMove?.(nodes);
-          newPtr.after(.../** @type {*} */ (nodes));
-        }
-        lastInserted = nodes[nodes.length - 1] ?? lastInserted;
-        i++;
       }
 
-      if (batchAdd.childNodes.length) lastInserted.after(batchAddLike);
-      cacheFromLastRun = newCache;
-    });
+      const isNewItemInstance = !nodes[0]?.parentNode;
+      if (isNewItemInstance) {
+        batchAddLike.append(...nodes);
+        i++;
+        continue;
+      }
+
+      if (batchAdd.childNodes.length === 0) {
+        onBeforeNodesMove?.(nodes);
+        lastInserted.after(.../** @type {*} */ (nodes));
+      } else {
+        const newPtr = /** @type {ChildNodeLike} */ (
+          batchAdd.childNodes[batchAdd.childNodes.length - 1]
+        );
+        lastInserted.after(batchAddLike);
+        onBeforeNodesMove?.(nodes);
+        newPtr.after(.../** @type {*} */ (nodes));
+      }
+      lastInserted = nodes[nodes.length - 1] ?? lastInserted;
+      i++;
+    }
+
+    if (batchAdd.childNodes.length) lastInserted.after(batchAddLike);
+    cacheFromLastRun = newCache;
   };
 
   addCellListener(listStart, list, reactToListChanges, false);
-  return [listStart, ...initialSnapshot, listEnd];
+  return [listStart, ...initialResult, listEnd];
 }

--- a/packages/retend/source/library/if.js
+++ b/packages/retend/source/library/if.js
@@ -77,7 +77,8 @@ export function If(value, fnOrObject, elseFn) {
 
   /** @type {ReactiveCellFunction<T, typeof rangeStart, (Node | VDom.VNode)[]>} */
   const callback = function (_value) {
-    return withScopeSnapshot(scopeSnapshot, () => {
+    scopeSnapshot.node.dispose(); // cleanup previous effects
+    const results = withScopeSnapshot(scopeSnapshot, () => {
       /** @type {(Node | VDom.VNode)[]} */
       let nodes = [];
       let nextNode = this.nextSibling;
@@ -120,6 +121,8 @@ export function If(value, fnOrObject, elseFn) {
       this.after(.../** @type {*} */ (nodes));
       return nodes;
     });
+    scopeSnapshot.node.setup(); // run new effects
+    return results;
   };
 
   // see comment in switch.js

--- a/packages/retend/source/library/scope.js
+++ b/packages/retend/source/library/scope.js
@@ -1,4 +1,5 @@
 /** @import { JSX } from '../jsx-runtime/types.ts' */
+/** @import { useObserver } from './observer.js' */
 import { getGlobalContext } from '../context/index.js';
 import h from './jsx.js';
 import { generateChildNodes } from './utils.js';
@@ -343,9 +344,48 @@ export function combineScopes(...providers) {
 }
 
 /**
+ * A hook for managing side effects with cleanup, tied to a component's logical lifecycle.
  *
- * @param {SetupFn} effect
+ * The callback runs once when a component instance is initialized, ideal for tasks
+ * like setting timers, subscribing to data streams, or adding global event listeners.
+ * The callback can return a cleanup function to prevent memory leaks, automatically
+ * executed when the component instance is destroyed (e.g., when removed from a `<For>` list).
+ *
+ * @param {SetupFn} callback - Function executed once on component setup. If it returns
+ *   a function, that function is used for cleanup.
+ *
+ * @example
+ * ```tsx
+ * import { Cell, useSetupEffect } from 'retend';
+ *
+ * function LiveClock() {
+ *   const time = Cell.source(new Date().toTimeString());
+ *
+ *   useSetupEffect(() => {
+ *     const timerId = setInterval(() => time.set(new Date().toTimeString()), 1000);
+ *     return () => clearInterval(timerId);
+ *   });
+ *
+ *   return <p>Current time: {time}</p>;
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * useSetupEffect(() => {
+ *   const handleResize = () => console.log('Window resized!');
+ *   window.addEventListener('resize', handleResize);
+ *
+ *   return () => window.removeEventListener('resize', handleResize);
+ * });
+ * ```
+ *
+ * @remarks
+ * - This hook runs only once per component instance, similar to `useEffect(..., [])` in React. It does not re-run on updates.
+ * - For effects tied to a specific DOM element's presence on screen (like measuring its size), use `useObserver` instead.
+ *
+ * @see {@link useObserver} for DOM-based lifecycle effects.
  */
-export function onSetup(effect) {
-  getScopeSnapshot().node.addEffect(effect);
+export function useSetupEffect(callback) {
+  getScopeSnapshot().node.addEffect(callback);
 }

--- a/packages/retend/source/library/switch.js
+++ b/packages/retend/source/library/switch.js
@@ -74,7 +74,8 @@ export function Switch(value, cases, defaultCase) {
 
   /** @type {ReactiveCellFunction<ReturnType<typeof value.get>, typeof rangeStart, (Node | VDom.VNode)[]>} */
   const callback = function (value) {
-    return withScopeSnapshot(snapshot, () => {
+    snapshot.node.dispose(); // cleanup previous effects
+    const results = withScopeSnapshot(snapshot, () => {
       /** @type {(Node | VDom.VNode)[]} */
       let nodes = [];
       let nextNode = this.nextSibling;
@@ -106,6 +107,8 @@ export function Switch(value, cases, defaultCase) {
 
       return nodes;
     });
+    snapshot.node.setup(); // run new effects
+    return results;
   };
 
   // Don't use runAndListen with an outer array to store nodes.
@@ -174,7 +177,8 @@ Switch.OnProperty = (value, key, cases, defaultCase) => {
 
   /** @type {ReactiveCellFunction<any, any, any>} */
   const callback = function (cellValue) {
-    return withScopeSnapshot(snapshot, () => {
+    snapshot.node.dispose(); // cleanup previous effects
+    const results = withScopeSnapshot(snapshot, () => {
       /** @type {(Node | VDom.VNode)[]} */
       let nodes = [];
       let nextNode = this.nextSibling;
@@ -208,6 +212,8 @@ Switch.OnProperty = (value, key, cases, defaultCase) => {
 
       return nodes;
     });
+    snapshot.node.setup(); // run new effects
+    return results;
   };
 
   const firstRun = callback.bind(rangeStart)(cell.get());

--- a/packages/retend/source/plugin/hmr.js
+++ b/packages/retend/source/plugin/hmr.js
@@ -163,7 +163,8 @@ export function setupHMRBoundaries(value, fn) {
 
   /** @type {ReactiveCellFunction<Function, Node | VDom.VNode, void>} */
   const callback = function (_value) {
-    return withScopeSnapshot(scopeSnapshot, () => {
+    scopeSnapshot.node.dispose(); // cleanup previous effects
+    const results = withScopeSnapshot(scopeSnapshot, () => {
       const { window } = getGlobalContext();
       if (!matchContext(window, Modes.Interactive)) {
         const message = 'Cannot handle HMR in non-interactive environments';
@@ -211,6 +212,8 @@ export function setupHMRBoundaries(value, fn) {
       // listen for the next iteration.
       addCellListener(nodes[0], value, callback, false);
     });
+    scopeSnapshot.node.setup(); // run new effects
+    return results;
   };
 
   addCellListener(nodes[0], value, callback, false);

--- a/packages/retend/source/router/index.js
+++ b/packages/retend/source/router/index.js
@@ -1051,97 +1051,93 @@ export class Router extends EventTarget {
       );
       const simplePath = fullPathWithSearchAndHash.split('?')[0];
 
-      const outletSnapshot =
-        outlet.__originScopeSnapshot ?? createScopeSnapshot();
-      const result = withScopeSnapshot(outletSnapshot, () => {
-        if (!outlet || !currentMatchedRoute) return false;
-        // The current path must react before the page loads.
-        const oldOutletPath = outlet.getAttribute('data-path');
-        if (this.currentPath.get().fullPath !== fullPathWithSearchAndHash) {
-          this.currentPath.set({
-            name: currentMatchedRoute.name,
-            path: simplePath,
-            params: matchResult.params,
-            query: matchResult.searchQueryParams,
-            fullPath: fullPathWithSearchAndHash,
-            metadata: matchResult.metadata,
-            hash: matchResult.hash,
-          });
-        }
+      // The current path must react before the page loads.
+      const oldOutletPath = outlet.getAttribute('data-path');
+      if (this.currentPath.get().fullPath !== fullPathWithSearchAndHash) {
+        this.currentPath.set({
+          name: currentMatchedRoute.name,
+          path: simplePath,
+          params: matchResult.params,
+          query: matchResult.searchQueryParams,
+          fullPath: fullPathWithSearchAndHash,
+          metadata: matchResult.metadata,
+          hash: matchResult.hash,
+        });
+      }
 
-        outlet.setAttribute('data-path', simplePath);
+      outlet.setAttribute('data-path', simplePath);
 
-        /** @type {JSX.Template} */
-        let renderedComponent;
-        const routeSnapshot = outlet.__keepAliveCache?.get(simplePath);
-        if (routeSnapshot) {
-          renderedComponent = [...routeSnapshot.fragment.childNodes];
-        } else {
-          try {
-            renderedComponent = h(matchedComponent, {});
-          } catch (error) {
-            if (oldOutletPath) {
-              outlet.setAttribute('data-path', oldOutletPath);
-            } else {
-              outlet.removeAttribute('data-path');
-            }
-            console.error(error);
-            if (error instanceof Error)
-              this.dispatchEvent(new RouteErrorEvent({ error }));
-            return false;
+      /** @type {JSX.Template} */
+      let renderedComponent;
+      const routeSnapshot = outlet.__keepAliveCache?.get(simplePath);
+      const oldSnapshot = outlet.__originScopeSnapshot;
+      if (routeSnapshot) {
+        renderedComponent = [...routeSnapshot.fragment.childNodes];
+      } else {
+        try {
+          if (oldSnapshot) {
+            renderedComponent = withScopeSnapshot(oldSnapshot, () =>
+              h(matchedComponent, {})
+            );
+          } else renderedComponent = h(matchedComponent, {});
+        } catch (error) {
+          if (oldOutletPath) {
+            outlet.setAttribute('data-path', oldOutletPath);
+          } else {
+            outlet.removeAttribute('data-path');
           }
+          console.error(error);
+          if (error instanceof Error)
+            this.dispatchEvent(new RouteErrorEvent({ error }));
+          return false;
         }
+      }
 
-        matchedComponent.__routeLevelFunction = true;
-        matchedComponent.__renderedOutlet = new WeakRef(outlet);
-        matchedComponent.__renderedPath = fullPathWithSearchAndHash;
+      matchedComponent.__routeLevelFunction = true;
+      matchedComponent.__renderedOutlet = new WeakRef(outlet);
+      matchedComponent.__renderedPath = fullPathWithSearchAndHash;
 
-        // if the component performs a redirect internally, it would change the route
-        // stored in the outlet's dataset, so we need to check before replacing.
-        if (outlet.getAttribute('data-path') !== simplePath) return false;
+      // if the component performs a redirect internally, it would change the route
+      // stored in the outlet's dataset, so we need to check before replacing.
+      if (outlet.getAttribute('data-path') !== simplePath) return false;
 
-        // There is no feasible way to determine the final navigation direction
-        // for view transitions, without already triggering a view transition.
-        // Mind bending nonsense.
-        const navigationDirection = this.chooseNavigationDirection(
-          fullPathWithSearchAndHash,
-          replace
+      // There is no feasible way to determine the final navigation direction
+      // for view transitions, without already triggering a view transition.
+      // Mind bending nonsense.
+      const navigationDirection = this.chooseNavigationDirection(
+        fullPathWithSearchAndHash,
+        replace
+      );
+      viewTransitionTypesArray[0] = navigationDirection;
+      if (currentMatchedRoute.transitionType) {
+        viewTransitionTypesArray[1] = currentMatchedRoute.transitionType;
+      }
+
+      // if the outlet is keep alive, we need to cache the current nodes
+      if (oldOutletPath) {
+        this.#preserveCurrentOutletState(oldOutletPath, outlet);
+      }
+
+      const nodes = generateChildNodes(renderedComponent);
+      if (nodes.some((node) => '__promise' in node)) {
+        // We want async top route components to render before the route changes.
+        await Promise.all(
+          nodes.map((node) =>
+            '__promise' in node ? node.__promise : undefined
+          )
         );
-        viewTransitionTypesArray[0] = navigationDirection;
-        if (currentMatchedRoute.transitionType) {
-          viewTransitionTypesArray[1] = currentMatchedRoute.transitionType;
-        }
+      }
+      const newNodesFragment = this.handleRelays(outlet, nodes);
+      if (newNodesFragment) {
+        renderRouteIntoOutlet(outlet, newNodesFragment, this.#window);
+      }
 
-        // if the outlet is keep alive, we need to cache the current nodes
-        if (oldOutletPath) {
-          this.#preserveCurrentOutletState(oldOutletPath, outlet);
-        }
-
-        const nodes = generateChildNodes(renderedComponent);
-        if (nodes.some((node) => '__promise' in node)) {
-          // TODO: Yes, there should be an await here, but async is like a virus,
-          // and if it has to be here, suddenly all of Retend will have to
-          // run asynchronously. Async components were a terrible, terrible idea.
-          Promise.all(
-            nodes.map((node) =>
-              '__promise' in node ? node.__promise : undefined
-            )
-          );
-        }
-        const newNodesFragment = this.handleRelays(outlet, nodes);
-        if (newNodesFragment) {
-          renderRouteIntoOutlet(outlet, newNodesFragment, this.#window);
-        }
-
-        lastMatchedRoute = currentMatchedRoute;
-        currentMatchedRoute = currentMatchedRoute.child;
-        return true;
-      });
-
-      if (!result) return false;
-
-      const nextOutlet = outlet.querySelector('retend-router-outlet');
-      outlet = /** @type {RouterOutlet} */ (nextOutlet);
+      lastMatchedRoute = currentMatchedRoute;
+      currentMatchedRoute = currentMatchedRoute.child;
+      const nextOutlet = /** @type {RouterOutlet} */ (
+        outlet.querySelector('retend-router-outlet')
+      );
+      outlet = nextOutlet;
     }
 
     // If the route tree traversal is exhausted, but there is still a nested

--- a/tests/scope/index.spec.tsx
+++ b/tests/scope/index.spec.tsx
@@ -403,7 +403,7 @@ const runTests = () => {
 
     it('should handle empty snapshots', () => {
       const emptySnapshot = createScopeSnapshot();
-      expect(emptySnapshot.size).toBe(0);
+      expect(emptySnapshot.scopes.size).toBe(0);
       const result = withScopeSnapshot(emptySnapshot, () => {
         return 'test-result';
       });

--- a/tests/scope/use-setup-effect.spec.tsx
+++ b/tests/scope/use-setup-effect.spec.tsx
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { useSetupEffect, If, Cell, For, Switch } from 'retend';
+import { createWebRouter, defineRoutes, useRouter } from 'retend/router';
+import { getGlobalContext, resetGlobalContext } from 'retend/context';
+import { routerSetupBrowser, getTextContent, browserSetup } from '../setup.ts';
+
+describe('useSetupEffect', () => {
+  describe('with components', () => {
+    browserSetup();
+    afterAll(() => {
+      resetGlobalContext();
+    });
+
+    it('works in an If() branch', () => {
+      const show = Cell.source(false);
+      const setupFn = vi.fn();
+      const cleanupFn = vi.fn();
+
+      const ComponentWithEffect = () => {
+        useSetupEffect(() => {
+          setupFn();
+          return () => {
+            cleanupFn();
+          };
+        });
+        return <div>Component</div>;
+      };
+
+      const App = () => {
+        return (
+          <div>
+            {If(show, () => (
+              <ComponentWithEffect />
+            ))}
+          </div>
+        );
+      };
+
+      const result = App() as HTMLElement;
+
+      expect(setupFn).not.toHaveBeenCalled();
+      expect(cleanupFn).not.toHaveBeenCalled();
+      expect(getTextContent(result)).toBe('');
+
+      show.set(true);
+      expect(setupFn).toHaveBeenCalledTimes(1);
+      expect(cleanupFn).not.toHaveBeenCalled();
+      expect(getTextContent(result)).toBe('Component');
+
+      show.set(false);
+      expect(setupFn).toHaveBeenCalledTimes(1);
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+      expect(getTextContent(result)).toBe('');
+
+      show.set(true);
+      expect(setupFn).toHaveBeenCalledTimes(2);
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+      expect(getTextContent(result)).toBe('Component');
+    });
+
+    it('works in a For() loop', () => {
+      const list = Cell.source([
+        { id: 1, text: 'A' },
+        { id: 2, text: 'B' },
+      ]);
+      const setupFns = new Map<number, ReturnType<typeof vi.fn>>();
+      const cleanupFns = new Map<number, ReturnType<typeof vi.fn>>();
+
+      const ComponentWithEffect = ({
+        item,
+      }: {
+        item: { id: number; text: string };
+      }) => {
+        if (!setupFns.has(item.id)) {
+          setupFns.set(item.id, vi.fn());
+          cleanupFns.set(item.id, vi.fn());
+        }
+
+        useSetupEffect(() => {
+          setupFns.get(item.id)!();
+          return () => {
+            cleanupFns.get(item.id)!();
+          };
+        });
+        return <div>{item.text}</div>;
+      };
+
+      const App = () => {
+        return (
+          <div>
+            {For(
+              list,
+              (item) => (
+                <ComponentWithEffect item={item} />
+              ),
+              {
+                key: 'id',
+              }
+            )}
+          </div>
+        );
+      };
+
+      const result = App() as HTMLElement;
+
+      expect(getTextContent(result)).toBe('AB');
+      expect(setupFns.get(1)!).toHaveBeenCalledTimes(1);
+      expect(setupFns.get(2)!).toHaveBeenCalledTimes(1);
+      expect(cleanupFns.get(1)!).not.toHaveBeenCalled();
+      expect(cleanupFns.get(2)!).not.toHaveBeenCalled();
+
+      list.set([{ id: 1, text: 'A' }]);
+      expect(getTextContent(result)).toBe('A');
+      expect(setupFns.get(1)!).toHaveBeenCalledTimes(1);
+      expect(setupFns.get(2)!).toHaveBeenCalledTimes(1);
+      expect(cleanupFns.get(1)!).not.toHaveBeenCalled();
+      expect(cleanupFns.get(2)!).toHaveBeenCalledTimes(1);
+
+      list.set([
+        { id: 1, text: 'A' },
+        { id: 3, text: 'C' },
+      ]);
+      expect(getTextContent(result)).toBe('AC');
+      expect(setupFns.get(1)!).toHaveBeenCalledTimes(1);
+      expect(setupFns.get(3)!).toBeDefined();
+      expect(setupFns.get(3)!).toHaveBeenCalledTimes(1);
+      expect(cleanupFns.get(1)!).not.toHaveBeenCalled();
+      expect(cleanupFns.get(3)!).not.toHaveBeenCalled();
+
+      list.set([]);
+      expect(getTextContent(result)).toBe('');
+      expect(cleanupFns.get(1)!).toHaveBeenCalledTimes(1);
+      expect(cleanupFns.get(2)!).toHaveBeenCalledTimes(1);
+      expect(cleanupFns.get(3)!).toHaveBeenCalledTimes(1);
+    });
+
+    it('works in a Switch() statement', () => {
+      const state = Cell.source<'A' | 'B' | 'C'>('A');
+      const setupFn = vi.fn();
+      const cleanupFn = vi.fn();
+
+      const ComponentWithEffect = () => {
+        useSetupEffect(() => {
+          setupFn();
+          return () => {
+            cleanupFn();
+          };
+        });
+        return <div>Effect Component</div>;
+      };
+
+      const App = () => {
+        return (
+          <div>
+            {Switch(state, {
+              A: () => <div>Case A</div>,
+              B: () => <ComponentWithEffect />,
+              C: () => <div>Case C</div>,
+            })}
+          </div>
+        );
+      };
+
+      const result = App() as HTMLElement;
+
+      expect(getTextContent(result)).toBe('Case A');
+      expect(setupFn).not.toHaveBeenCalled();
+      expect(cleanupFn).not.toHaveBeenCalled();
+
+      state.set('B');
+      expect(getTextContent(result)).toBe('Effect Component');
+      expect(setupFn).toHaveBeenCalledTimes(1);
+      expect(cleanupFn).not.toHaveBeenCalled();
+
+      state.set('C');
+      expect(getTextContent(result)).toBe('Case C');
+      expect(setupFn).toHaveBeenCalledTimes(1);
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+
+      state.set('B');
+      expect(getTextContent(result)).toBe('Effect Component');
+      expect(setupFn).toHaveBeenCalledTimes(2);
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+
+      state.set('A');
+      expect(getTextContent(result)).toBe('Case A');
+      expect(setupFn).toHaveBeenCalledTimes(2);
+      expect(cleanupFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // describe('with routing', () => {
+  //   beforeEach(() => {
+  //     routerSetupBrowser();
+  //   });
+
+  //   afterAll(() => {
+  //     resetGlobalContext();
+  //   });
+
+  //   const setupFn = vi.fn();
+  //   const cleanupFn = vi.fn();
+
+  //   const EffectComponent = () => {
+  //     useSetupEffect(() => {
+  //       setupFn();
+  //       return cleanupFn;
+  //     });
+  //     return <div>Effect Component</div>;
+  //   };
+
+  //   const OtherComponent = () => <div>Other Component</div>;
+
+  //   const App = (props: { keepAlive?: boolean }) => {
+  //     const { Outlet } = useRouter();
+  //     return (
+  //       <div>
+  //         <Outlet keepAlive={props.keepAlive} />
+  //       </div>
+  //     );
+  //   };
+
+  //   const routes = (props: { keepAlive?: boolean }) =>
+  //     defineRoutes([
+  //       {
+  //         path: '/',
+  //         component: () => <App {...props} />,
+  //         children: [
+  //           { path: 'effect', component: EffectComponent },
+  //           { path: 'other', component: OtherComponent },
+  //         ],
+  //       },
+  //     ]);
+
+  //   it('should run setup and cleanup on navigation (keepAlive=false)', async () => {
+  //     const { window } = getGlobalContext();
+  //     setupFn.mockClear();
+  //     cleanupFn.mockClear();
+
+  //     const router = createWebRouter({ routes: routes({ keepAlive: false }) });
+  //     router.setWindow(window);
+  //     router.attachWindowListeners();
+
+  //     await router.navigate('/effect');
+  //     expect(getTextContent(window.document.body)).toBe('Effect Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(1);
+  //     expect(cleanupFn).not.toHaveBeenCalled();
+
+  //     await router.navigate('/other');
+  //     expect(getTextContent(window.document.body)).toBe('Other Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(1);
+  //     expect(cleanupFn).toHaveBeenCalledTimes(1);
+
+  //     await router.navigate('/effect');
+  //     expect(getTextContent(window.document.body)).toBe('Effect Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(2);
+  //     expect(cleanupFn).toHaveBeenCalledTimes(1);
+  //   });
+
+  //   it('should dispose and re-run effects with keepAlive=true', async () => {
+  //     const { window } = getGlobalContext();
+  //     setupFn.mockClear();
+  //     cleanupFn.mockClear();
+
+  //     const router = createWebRouter({ routes: routes({ keepAlive: true }) });
+  //     router.setWindow(window);
+  //     router.attachWindowListeners();
+
+  //     await router.navigate('/effect');
+  //     expect(getTextContent(window.document.body)).toBe('Effect Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(1);
+  //     expect(cleanupFn).not.toHaveBeenCalled();
+
+  //     await router.navigate('/other');
+  //     expect(getTextContent(window.document.body)).toBe('Other Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(1);
+  //     expect(cleanupFn).toHaveBeenCalledTimes(1);
+
+  //     await router.navigate('/effect');
+  //     expect(getTextContent(window.document.body)).toBe('Effect Component');
+  //     expect(setupFn).toHaveBeenCalledTimes(2);
+  //     expect(cleanupFn).toHaveBeenCalledTimes(1);
+  //   });
+  // });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -25,8 +25,33 @@ export const routerSetup = () => {
   });
 };
 
+
+export const routerSetupBrowser = () => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+
+  GlobalRegistrator.register({
+    url: 'http://localhost:8080',
+  });
+  window.document.body.append(
+    window.document.createElement('retend-router-outlet')
+  );
+
+  setGlobalContext({
+    mode: Modes.Interactive,
+    window,
+    consistentValues: new Map(),
+    globalData: new Map(),
+    teleportIdCounter: { value: 0 },
+  });
+};
+
 export const browserSetup = () => {
   beforeAll(() => {
+    if (GlobalRegistrator.isRegistered) {
+      GlobalRegistrator.unregister();
+    }
     GlobalRegistrator.register();
   });
 


### PR DESCRIPTION
This pull request introduces a new hook, `useSetupEffect`, for managing side effects tied to a component's *logical* lifecycle. It provides a reliable way to run code when a component instance is created and to perform cleanup when it's destroyed, especially within dynamic control flow structures like `<For>` and `<If>`.

This is a foundational feature for building stateful, side-effectful components, enabling patterns like subscriptions, timers, and event listeners that are correctly managed without memory leaks.

---

### The Motivation: `useSetupEffect` vs. `useObserver`

A key question is: "Why not just use `useObserver` for this?" The answer lies in the distinction between a **DOM element's lifecycle** and a **component's logical lifecycle**.

-   **`useObserver` is for the DOM lifecycle.** It triggers callbacks when a specific DOM element is connected to or disconnected from the document. This is perfect for tasks that directly involve a DOM node, such as:
    -   Measuring element size (`getBoundingClientRect`).
    -   Setting up an `IntersectionObserver`.
    -   Integrating with a third-party library that needs a DOM element reference.
    -   **Limitation:** It requires the component to render a single, stable root DOM element that can be referenced. It fails for components that return fragments, text nodes, or render nothing at all.

-   **`useSetupEffect` is for the logical lifecycle.** It triggers callbacks based on when a component *instance* is created or destroyed by Retend's rendering logic. This is ideal for side effects that are not tied to a specific DOM element, such as:
    -   Setting up a `setInterval` or `setTimeout`.
    -   Subscribing to a WebSocket or a global event bus (`window.addEventListener('storage', ...)`).
    -   Fetching data when a component appears.
    -   **Advantage:** It works regardless of what the component renders—even if it returns an array of elements, a string, or nothing.

`useSetupEffect` fills a critical gap by providing a way to manage side effects for any component, decoupling the effect's lifecycle from the component's DOM output.

---

**Example Usage:**

The `LiveClock` example demonstrates a classic use case where `useObserver` would be inappropriate, as the timer's lifecycle isn't related to any specific DOM element.

```tsx
import { Cell, useSetupEffect } from 'retend';

function LiveClock() {
  const time = Cell.source(new Date().toLocaleTimeString());

  useSetupEffect(() => {
    // Setup runs once per component instance
    const timerId = setInterval(() => time.set(new Date().toLocaleTimeString()), 1000);
    
    // Cleanup runs when the instance is destroyed
    return () => clearInterval(timerId);
  });

  return <p>Current time: {time}</p>;
}
```

---

**Implementation Details:**

To enable this, we've introduced a lightweight effect management system into Retend's core scoping mechanism:

1.  **Effect Tree (`scope.js`):** A new `Node` class now manages a tree of setup and cleanup functions. Each component instance gets its own branch in this tree.
2.  **Enhanced Scopes:** `ScopeSnapshot` now tracks the current effect `Node`, ensuring effects are correctly associated with the component instance that declares them.
3.  **Control Flow Integration (`For`, `If`, `Switch`):** These components have been updated to intelligently manage the lifecycle of their children's effects. When a child is removed, its effect node is disposed (triggering cleanup). When a new child is added, its effect node is set up.