### PR TITLE
Add reactive refs for fragments

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,6 +12,7 @@
     "no-shadow": "off",
     "no-await-in-loop": "off",
     "react/react-in-jsx-scope": "off",
+    "react/jsx-key": "off",
     "react/no-unknown-property": "off",
     "react/jsx-max-depth": "off",
     "react/jsx-props-no-spreading": "off",

--- a/docs/content/04-special-attributes.mdx
+++ b/docs/content/04-special-attributes.mdx
@@ -125,7 +125,6 @@ Since `ref={cell}` is just a prop, you can pass it down to child components manu
 import { Cell, onSetup } from 'retend';
 
 function MyInput(props) {
-  // We take the 'ref' from props and pass it to the internal input
   return <input ref={props.ref} class="custom-input" />;
 }
 
@@ -133,10 +132,78 @@ export function ParentComponent() {
   const inputRef = Cell.source(null);
 
   onSetup(() => {
-    // We can access the child's input here!
     inputRef.get()?.focus();
   });
 
   return <MyInput ref={inputRef} />;
 }
 ```
+
+### Fragment refs
+
+A Fragment ref stores the nodes that a Fragment renders. Use a Fragment ref when you need to inspect or process multiple nodes without adding a wrapper element.
+
+To create a Fragment ref:
+
+1. Create a source cell with an initial value of `null`.
+2. Pass the cell to the Fragment's `ref` attribute.
+3. Read the rendered nodes with the cell's `get()` method.
+
+```tsx
+import { Cell, Fragment } from 'retend';
+
+export function MessageGroup() {
+  const nodesRef = Cell.source<Node[] | null>(null);
+
+  const logNodes = () => {
+    console.log(nodesRef.get());
+  };
+
+  return (
+    <>
+      <Fragment ref={nodesRef}>
+        <p>First message</p>
+        <p>Second message</p>
+      </Fragment>
+      <button onClick={logNodes}>Log messages</button>
+    </>
+  );
+}
+```
+
+Retend updates the ref cell whenever the Fragment's rendered content changes. The cell contains:
+
+- Each rendered element and text node, in document order.
+- An empty array when the Fragment renders no nodes.
+
+For example, the following ref changes when `showSuccess` changes:
+
+```tsx
+import { Cell, Fragment, If } from 'retend';
+
+export function StatusMessage() {
+  const showSuccess = Cell.source(true);
+  const nodesRef = Cell.source<Node[] | null>(null);
+
+  return (
+    <>
+      <Fragment ref={nodesRef}>
+        {If(
+          showSuccess,
+          () => (
+            <p>Saved</p>
+          ),
+          () => (
+            <p>Save failed</p>
+          )
+        )}
+      </Fragment>
+      <button onClick={() => showSuccess.set(!showSuccess.get())}>
+        Toggle status
+      </button>
+    </>
+  );
+}
+```
+
+Use an element ref when you need one specific element instead of the complete Fragment output.

--- a/packages/retend/package.json
+++ b/packages/retend/package.json
@@ -50,7 +50,7 @@
     "build": "node scripts/build.js"
   },
   "dependencies": {
-    "@adbl/cells": "^0.0.26",
+    "@adbl/cells": "^0.0.27",
     "csstype": "^3.2.3"
   },
   "devDependencies": {

--- a/packages/retend/source/_internals.js
+++ b/packages/retend/source/_internals.js
@@ -1,4 +1,7 @@
 /** @import { Renderer } from './library/renderer.js' */
+/** @import { Scope } from './library/scope.js' */
+
+import { useScopeContext } from './library/scope.js';
 import { linkNodes } from './library/utils.js';
 
 export const IgnoredHProps = /** @type {const} */ ([
@@ -20,3 +23,21 @@ export function createGroupFromNodes(input, renderer) {
   }
   return group;
 }
+
+/**
+ * @template T
+ * @param {Scope<T>} Scope
+ */
+export function getSafeScopeContext(Scope) {
+  try {
+    return useScopeContext(Scope);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @typedef {Object} FragmentTrackerData
+ * @property {WeakMap<object, unknown[]>} handleToNodes
+ * @property {WeakMap<object, unknown[]>} groupToNodes
+ */

--- a/packages/retend/source/library/await.js
+++ b/packages/retend/source/library/await.js
@@ -5,15 +5,11 @@
 /** @import { AsyncCell } from '@adbl/cells'; */
 import { Cell } from '@adbl/cells';
 
+import { getSafeScopeContext } from '../_internals.js';
 import { getGlobalContext } from '../context/index.js';
+import { useFragmentCtx } from './fragment.js';
 import { getActiveRenderer, normalizeJsxChild } from './index.js';
-import {
-  createScope,
-  branchState,
-  getState,
-  useScopeContext,
-  withState,
-} from './scope.js';
+import { createScope, branchState, getState, withState } from './scope.js';
 
 /**
  * @typedef {{
@@ -55,6 +51,7 @@ export function Await(props) {
   const { children, fallback } = props;
   const { globalData } = getGlobalContext();
   const renderer = getActiveRenderer();
+  const fragmentCtx = useFragmentCtx();
   const asyncHolders = globalData.get(AsyncKey) ?? new Set();
   globalData.set(AsyncKey, asyncHolders);
   const initialStateDone = Cell.source(false);
@@ -127,6 +124,7 @@ export function Await(props) {
 
   const showContent = () => {
     fallbackSnapshot.node.dispose();
+    fragmentCtx?.correlate(group, [render].flat(), handle);
     renderer.write(handle, [render].flat());
     snapshot.node.unsuspend();
     snapshot.node.enable();
@@ -140,7 +138,9 @@ export function Await(props) {
     const fallbackNodes = withState(fallbackSnapshot, () =>
       renderer.handleComponent(() => fallback ?? null, [], fallbackSnapshot)
     );
-    renderer.write(handle, [fallbackNodes].flat());
+    const fallbackLogical = [fallbackNodes].flat();
+    fragmentCtx?.correlate(group, fallbackLogical, handle);
+    renderer.write(handle, fallbackLogical);
   }
   return group;
 }
@@ -155,11 +155,7 @@ export function Await(props) {
  * @returns {AwaitContext | null}
  */
 export function useAwait() {
-  try {
-    return useScopeContext(AwaitScope);
-  } catch {
-    return null;
-  }
+  return getSafeScopeContext(AwaitScope);
 }
 
 /**

--- a/packages/retend/source/library/await.js
+++ b/packages/retend/source/library/await.js
@@ -102,9 +102,8 @@ export function Await(props) {
 
   const group = renderer.createGroup();
   const handle = renderer.createGroupHandle(group);
-  const snapshot = branchState();
+  const snapshot = branchState('deferred');
   snapshot.data = { handle };
-  snapshot.node.suspend();
   const fallbackSnapshot = branchState();
   fallbackSnapshot.data = { handle };
 
@@ -126,8 +125,6 @@ export function Await(props) {
     fallbackSnapshot.node.dispose();
     fragmentCtx?.correlate(group, [render].flat(), handle);
     renderer.write(handle, [render].flat());
-    snapshot.node.unsuspend();
-    snapshot.node.enable();
     asyncCells.set(new Set());
     snapshot.node.activate();
   };

--- a/packages/retend/source/library/block.js
+++ b/packages/retend/source/library/block.js
@@ -1,13 +1,14 @@
 /** @import { Renderer } from './renderer.js' */
-import { AsyncCell } from '@adbl/cells';
+import { AsyncCell, SourceCell } from '@adbl/cells';
 
 import { useAwait } from './await.js';
+import { Fragment, FragmentPlaceholder, useFragmentCtx } from './fragment.js';
 import { createNodesFromTemplate, linkNodes } from './utils.js';
 
 export class Block {
   /**
    * @param {string | Function | FragmentPlaceholder} tagOrFn
-   * @param {*} props
+   * @param {any} props
    * @param {*} fileData
    */
   constructor(tagOrFn, props, fileData) {
@@ -27,9 +28,15 @@ export class Block {
     const { fileData, kind, props, tagOrFn } = this;
 
     if (kind === 2) {
-      const group = renderer.createGroup();
-      linkNodes(group, props?.children, renderer);
-      return group;
+      if (!('ref' in props && props.ref instanceof SourceCell)) {
+        const group = renderer.createGroup();
+        const children = createNodesFromTemplate(props?.children, renderer);
+        linkNodes(group, children, renderer);
+        const parentFragmentRefCtx = useFragmentCtx();
+        parentFragmentRefCtx?.correlate(group, children);
+        return group;
+      }
+      return Fragment(props, renderer);
     }
 
     if (kind === 1) {
@@ -56,5 +63,3 @@ export class Block {
     return linkNodes(container, children, renderer);
   }
 }
-
-export class FragmentPlaceholder {}

--- a/packages/retend/source/library/for.js
+++ b/packages/retend/source/library/for.js
@@ -4,6 +4,7 @@
 import { Cell, AsyncCell } from '@adbl/cells';
 
 import { useAwait } from './await.js';
+import { useFragmentCtx } from './fragment.js';
 import { getActiveRenderer } from './renderer.js';
 import { branchState, withState } from './scope.js';
 
@@ -124,9 +125,10 @@ export function For(list, fn, options) {
     // REACTIVE LISTS
     // -----------------------------------------------
     const { key, onBeforeNodeRemove, onBeforeNodesMove } = options ?? {};
-    /** @type {Map<any, { index: Cell<number>,  nodes: unknown[], snapshot: StateSnapshot }>} */
+    /** @type {Map<any, { index: Cell<number>,  nodes: unknown[], snapshot: StateSnapshot, groupedNodes: unknown[] }>} */
     let cacheFromLastRun = new Map();
     const autoKeys = new WeakMap();
+    const fragmentCtx = useFragmentCtx();
 
     /**
      * @param {any} item
@@ -177,9 +179,11 @@ export function For(list, fn, options) {
     const processListChanges = (listValue, initial = false) => {
       const newList =
         typeof listValue?.[Symbol.iterator] === 'function' ? listValue : [];
+      /** @type {typeof cacheFromLastRun} */
       const newCache = new Map();
       const effectNodesToActivate = [];
       const initialNodes = [];
+      const initialGroupedNodes = [];
       /** @type {Map<unknown, { itemKey: any, lastItemLastNode: unknown | null }>} */
       const nodeLookAhead = new Map();
 
@@ -198,34 +202,46 @@ export function For(list, fn, options) {
             renderer: base.renderer,
             data: base.data,
           };
-          const nodes = flattenNodes(
-            withState(snapshot, () =>
-              renderer.handleComponent(fn, parameters, snapshot)
-            ),
-            renderer
+          const raw = withState(snapshot, () =>
+            renderer.handleComponent(fn, parameters, snapshot)
           );
+          // We store the unflattened version of the nodes so we can use groups
+          // as references for retrieval in the Fragment ref context.
+          const groupedNodes = Array.isArray(raw) ? raw : [raw];
+          const nodes = flattenNodes(groupedNodes, renderer);
           trackNodes(nodes);
-          result = { nodes, index: itemIndex, snapshot };
+          result = { nodes, index: itemIndex, snapshot, groupedNodes };
           if (!initial) effectNodesToActivate.push(snapshot.node);
         } else {
           /** @type {import('@adbl/cells').SourceCell<number>} */
           (result.index).set(index);
         }
         newCache.set(itemKey, result);
-        const { nodes } = result;
-        if (initial) initialNodes.push(...nodes);
-        else if (nodes[0]) {
+        const { nodes, groupedNodes } = result;
+        if (initial) {
+          initialNodes.push(...nodes);
+          initialGroupedNodes.push(...groupedNodes);
+        } else if (nodes[0]) {
           nodeLookAhead.set(nodes[0], { itemKey, lastItemLastNode });
         }
         lastItemLastNode = nodes[nodes.length - 1];
         index++;
       }
 
-      if (initial) renderer.write(handle, initialNodes);
-      else {
+      if (initial) {
+        fragmentCtx?.correlate(group, initialGroupedNodes, handle);
+        renderer.write(handle, initialNodes);
+      } else {
         for (const [itemKey, { snapshot }] of cacheFromLastRun) {
           if (newCache.has(itemKey)) continue;
           snapshot.node.dispose();
+        }
+        if (fragmentCtx) {
+          const logicalNodes = [];
+          for (const [, result] of newCache) {
+            logicalNodes.push(...result.groupedNodes);
+          }
+          fragmentCtx.correlate(group, logicalNodes, handle);
         }
         renderer.reconcile(handle, {
           cacheFromLastRun,

--- a/packages/retend/source/library/fragment.js
+++ b/packages/retend/source/library/fragment.js
@@ -5,9 +5,11 @@ import { getSafeScopeContext } from '../_internals.js';
 import { getGlobalContext } from '../context/index.js';
 import { createScope } from './scope.js';
 import { createNodesFromTemplate, linkNodes } from './utils.js';
+
 /**
  * @typedef {Object} FragmentContext
  * @property {(group: any, nodes: any, handle?: any) => void} correlate
+ * @property {() => void} invalidate
  */
 
 /**
@@ -84,31 +86,10 @@ export function correlate(group, nodes, renderer, handle) {
 }
 
 /**
- *
- * @param {FragmentProps & { ref: SourceCell<any[] | null> }} props
- * @param {Renderer<any>} renderer
+ * @param {any[]} nodes
+ * @param {WeakMap<any, any[]>} groupToNodes
  */
-export function Fragment(props, renderer) {
-  const { ref, children } = props;
-  const parentCtx = useFragmentCtx();
-  const { handleToNodes, groupToNodes } = getGlobalFragmentStash(renderer);
-
-  /** @type {FragmentContext} */
-  const context = {
-    correlate(group, nodes, handle) {
-      groupToNodes.set(group, nodes);
-      if (handle) handleToNodes.set(handle, nodes);
-    },
-  };
-
-  const nodes = /** @type {object[]} */ (
-    TrackedFragmentScope.Provider({
-      value: context,
-      h: false,
-      children: () => createNodesFromTemplate(children, renderer),
-    })
-  );
-
+function resolveLeafs(nodes, groupToNodes) {
   const leafs = [];
   /** @type {object[]} */
   const stack = [];
@@ -123,7 +104,44 @@ export function Fragment(props, renderer) {
     }
   }
 
-  ref.set(leafs);
+  return leafs;
+}
+
+/**
+ *
+ * @param {FragmentProps & { ref: SourceCell<any[] | null> }} props
+ * @param {Renderer<any>} renderer
+ */
+export function Fragment(props, renderer) {
+  const { ref, children } = props;
+  const parentCtx = useFragmentCtx();
+  let initialized = false;
+  const { handleToNodes, groupToNodes } = getGlobalFragmentStash(renderer);
+
+  /** @type {FragmentContext} */
+  const context = {
+    correlate(group, nodes, handle) {
+      groupToNodes.set(group, nodes);
+      if (handle) handleToNodes.set(handle, nodes);
+      context.invalidate();
+    },
+    invalidate() {
+      if (!initialized) return;
+      ref.set(resolveLeafs(nodes, groupToNodes));
+      parentCtx?.invalidate();
+    },
+  };
+
+  const nodes = /** @type {object[]} */ (
+    TrackedFragmentScope.Provider({
+      value: context,
+      h: false,
+      children: () => createNodesFromTemplate(children, renderer),
+    })
+  );
+
+  ref.set(resolveLeafs(nodes, groupToNodes));
+  initialized = true;
   const group = renderer.createGroup();
   linkNodes(group, nodes, renderer);
   parentCtx?.correlate(group, nodes);

--- a/packages/retend/source/library/fragment.js
+++ b/packages/retend/source/library/fragment.js
@@ -1,0 +1,111 @@
+/** @import { Renderer, Scope, SourceCell } from './index.js'; */
+/** @import { JSX } from '../jsx-runtime/index.js' */
+
+import { getSafeScopeContext } from '../_internals.js';
+import { getGlobalContext } from '../context/index.js';
+import { createScope } from './scope.js';
+import { createNodesFromTemplate, linkNodes } from './utils.js';
+/**
+ * @typedef {Object} FragmentContext
+ * @property {(group: any, nodes: any, handle?: any) => void} correlate
+ */
+
+/**
+ * Props accepted by the JSX fragment (`<>...</>` / `<Fragment>`).
+ *
+ * @typedef {Object} FragmentProps
+ * @property {JSX.Children} [children]
+ * The fragment's content. A fragment renders its children directly into the
+ * parent element — it never creates a wrapper element of its own.
+ * @property {SourceCell<any[] | null>} [ref]
+ * When set, receives the nodes rendered inside the fragment as an array, so
+ * the fragment's output can be inspected as a single unit (an empty array
+ * when nothing is rendered). The value is updated whenever the fragment's
+ * content changes.
+ */
+
+const FragmentStashSymbol = Symbol('FragmentStash');
+
+/** @type {Scope<FragmentContext>} */
+export const TrackedFragmentScope = createScope('retend:Fragment');
+export function useFragmentCtx() {
+  return getSafeScopeContext(TrackedFragmentScope);
+}
+
+/**
+ * Represents a JSX fragment in your markup.
+ *
+ * Both `<>...</>` and `<Fragment>...</Fragment>` compile to this component. A
+ * fragment renders its children directly into the parent element without
+ * adding a wrapper element of its own.
+ *
+ * Passing a `ref` cell makes the fragment trackable: the cell receives the
+ * nodes rendered by the fragment's content (see `FragmentProps`).
+ *
+ * @param {FragmentProps} _props
+ */
+export function FragmentPlaceholder(_props) {}
+
+/**
+ *
+ * @param {FragmentProps & { ref: SourceCell<any[] | null> }} props
+ * @param {Renderer<any>} renderer
+ */
+export function Fragment(props, renderer) {
+  const { ref, children } = props;
+  const parentCtx = useFragmentCtx();
+  const { globalData } = getGlobalContext();
+  let allStashes = globalData.get(FragmentStashSymbol);
+  if (!allStashes) {
+    allStashes = new WeakMap();
+    globalData.set(FragmentStashSymbol, allStashes);
+  }
+  let rendererStash = allStashes.get(renderer);
+  if (!rendererStash) {
+    rendererStash = {
+      handleToNodes: new WeakMap(),
+      groupToNodes: new WeakMap(),
+    };
+    allStashes.set(renderer, rendererStash);
+  }
+
+  const { handleToNodes, groupToNodes } = rendererStash;
+
+  /** @type {FragmentContext} */
+  const context = {
+    correlate(group, nodes, handle) {
+      groupToNodes.set(group, nodes);
+      if (handle) {
+        handleToNodes.set(handle, nodes);
+      }
+    },
+  };
+
+  const nodes = /** @type {object[]} */ (
+    TrackedFragmentScope.Provider({
+      value: context,
+      h: false,
+      children: () => createNodesFromTemplate(children, renderer),
+    })
+  );
+
+  const leafs = [];
+  /** @type {object[]} */
+  const stack = [];
+  for (let i = nodes.length - 1; i >= 0; i -= 1) stack.push(nodes[i]);
+  while (stack.length > 0) {
+    const node = stack.pop();
+    const logical = groupToNodes.get(node);
+    if (logical) {
+      for (let i = logical.length - 1; i >= 0; i -= 1) stack.push(logical[i]);
+    } else {
+      leafs.push(node);
+    }
+  }
+
+  ref.set(leafs);
+  const group = renderer.createGroup();
+  linkNodes(group, nodes, renderer);
+  parentCtx?.correlate(group, nodes);
+  return group;
+}

--- a/packages/retend/source/library/fragment.js
+++ b/packages/retend/source/library/fragment.js
@@ -47,13 +47,10 @@ export function useFragmentCtx() {
 export function FragmentPlaceholder(_props) {}
 
 /**
- *
- * @param {FragmentProps & { ref: SourceCell<any[] | null> }} props
  * @param {Renderer<any>} renderer
+ * @returns {{ handleToNodes: WeakMap<any, any>, groupToNodes: WeakMap<any, any> }}
  */
-export function Fragment(props, renderer) {
-  const { ref, children } = props;
-  const parentCtx = useFragmentCtx();
+export function getGlobalFragmentStash(renderer) {
   const { globalData } = getGlobalContext();
   let allStashes = globalData.get(FragmentStashSymbol);
   if (!allStashes) {
@@ -69,15 +66,38 @@ export function Fragment(props, renderer) {
     allStashes.set(renderer, rendererStash);
   }
 
-  const { handleToNodes, groupToNodes } = rendererStash;
+  return rendererStash;
+}
+
+/**
+ * Allows fragment group correlation outside of a fragment context, specifically
+ * for Unique, since it manages many groups over the lifetime of the application.
+ * @param {any} group
+ * @param {any[]} nodes
+ * @param {Renderer<any>} renderer
+ * @param {any} [handle]
+ */
+export function correlate(group, nodes, renderer, handle) {
+  const { groupToNodes, handleToNodes } = getGlobalFragmentStash(renderer);
+  groupToNodes.set(group, nodes);
+  if (handle) handleToNodes.set(handle, nodes);
+}
+
+/**
+ *
+ * @param {FragmentProps & { ref: SourceCell<any[] | null> }} props
+ * @param {Renderer<any>} renderer
+ */
+export function Fragment(props, renderer) {
+  const { ref, children } = props;
+  const parentCtx = useFragmentCtx();
+  const { handleToNodes, groupToNodes } = getGlobalFragmentStash(renderer);
 
   /** @type {FragmentContext} */
   const context = {
     correlate(group, nodes, handle) {
       groupToNodes.set(group, nodes);
-      if (handle) {
-        handleToNodes.set(handle, nodes);
-      }
+      if (handle) handleToNodes.set(handle, nodes);
     },
   };
 

--- a/packages/retend/source/library/if.js
+++ b/packages/retend/source/library/if.js
@@ -3,6 +3,7 @@
 import { Cell, AsyncCell } from '@adbl/cells';
 
 import { useAwait } from './await.js';
+import { useFragmentCtx } from './fragment.js';
 import { getActiveRenderer } from './renderer.js';
 import { branchState, withState } from './scope.js';
 
@@ -86,6 +87,7 @@ export function If(value, fnOrObject, elseFn) {
 
     const stateSnapshot = branchState();
     if (value instanceof AsyncCell) useAwait()?.waitUntil(value);
+    const fragmentCtx = useFragmentCtx();
 
     if (typeof fnOrObject === 'function' && !fnOrObject.name) {
       Object.defineProperty(fnOrObject, 'name', { value: 'If.True' });
@@ -121,7 +123,9 @@ export function If(value, fnOrObject, elseFn) {
      */
     const processValueChange = (nextValue) => {
       stateSnapshot.node.dispose();
-      renderer.write(handle, callback(nextValue));
+      const nextNodes = callback(nextValue);
+      fragmentCtx?.correlate(group, nextNodes, handle);
+      renderer.write(handle, nextNodes);
       stateSnapshot.node.activate();
     };
 
@@ -141,7 +145,9 @@ export function If(value, fnOrObject, elseFn) {
       return group;
     }
 
-    renderer.write(handle, callback(initialValue));
+    const nodes = callback(initialValue);
+    fragmentCtx?.correlate(group, nodes, handle);
+    renderer.write(handle, nodes);
     return group;
   };
 }

--- a/packages/retend/source/library/index.js
+++ b/packages/retend/source/library/index.js
@@ -1,5 +1,6 @@
 export * from './jsx.js';
 export * from './block.js';
+export { FragmentPlaceholder } from './fragment.js';
 export * from './for.js';
 export * from './if.js';
 export * from './switch.js';

--- a/packages/retend/source/library/jsx.js
+++ b/packages/retend/source/library/jsx.js
@@ -1,5 +1,6 @@
 /** @import { JSX } from '../jsx-runtime/index.js'; */
-import { Block, FragmentPlaceholder } from './block.js';
+import { Block } from './block.js';
+import { FragmentPlaceholder } from './fragment.js';
 
 /**
  * @param {string | Function} tagOrFn

--- a/packages/retend/source/library/scope.js
+++ b/packages/retend/source/library/scope.js
@@ -143,6 +143,13 @@ class EffectNode {
   #enabled = false;
   #suspended = false;
   #active = false;
+  /**
+   * When set, a parent's dispose cascade has no effect on this node: its
+   * cleanups do not run, its subtree is not destroyed, and its local context
+   * survives. Used by createUnique to keep a moving instance's scope alive;
+   * only an explicit dispose() (which clears the protection) tears it down.
+   */
+  #disposeProtected = false;
   localContext = Cell.context();
   /** @type {Renderer<any>} | undefined */
   renderer = getActiveRenderer();
@@ -178,6 +185,15 @@ class EffectNode {
   disable() {
     this.#enabled = false;
     for (const child of this.#children) child.disable();
+  }
+
+  /**
+   * Marks this node so a parent's dispose cascade has no effect on it — its
+   * cleanups are deferred, its subtree is not destroyed, and its local
+   * context survives. The node is still torn down by an explicit dispose().
+   */
+  protectFromDispose() {
+    this.#disposeProtected = true;
   }
 
   /** @param {SetupFn} effect  */
@@ -266,6 +282,10 @@ class EffectNode {
 
   #runDisposeFns() {
     if (!this.#enabled && this.#active) return false;
+    // A preserved node (e.g. a Unique being moved) must not run its cleanups
+    // either: the cascade reaching it is a location teardown, not the end of
+    // its journey. An explicit dispose() clears the protection first.
+    if (this.#disposeProtected) return false;
     for (const effect of this.#disposeFns) runCleanup(effect);
     this.#active = false;
     for (const child of this.#children) child.#runDisposeFns();
@@ -282,6 +302,7 @@ class EffectNode {
   }
 
   dispose() {
+    this.#disposeProtected = false;
     if (!this.#runDisposeFns()) return;
     this.#runConnectedDisposeFns();
 

--- a/packages/retend/source/library/scope.js
+++ b/packages/retend/source/library/scope.js
@@ -52,6 +52,16 @@ import { createNodesFromTemplate, normalizeJsxChild } from './utils.js';
  * @property {any} [data]
  */
 
+/** @typedef {'normal' | 'deferred' | 'retained'} LifecycleMode */
+
+const EffectPhase = Object.freeze({
+  Blocked: 0,
+  Deferred: 1,
+  Eligible: 2,
+  Active: 3,
+  Orphaned: 4,
+});
+/** @typedef {0 | 1 | 2 | 3 | 4} EffectPhaseValue */
 /** @typedef {() => void} CleanupFn */
 /** @typedef {void | CleanupFn | Promise<void | CleanupFn>} EffectResult */
 /** @template T @typedef {(node: T) => EffectResult} MountFn */
@@ -126,7 +136,7 @@ function updateConnectedEffect(effect, next) {
 
 /**
  * Represents a node managing effects and cleanup within a hierarchy.
- * Allows enabling/disabling, forking child nodes, and disposing by cleaning effects and children.
+ * Supports deferred activation, retained ownership, child branches, and disposal.
  */
 class EffectNode {
   #id = '0';
@@ -140,60 +150,46 @@ class EffectNode {
   /** @type {ConnectedEffect[]} */
   #connectedEffects = [];
 
-  #enabled = false;
-  #suspended = false;
-  #active = false;
-  /**
-   * When set, a parent's dispose cascade has no effect on this node: its
-   * cleanups do not run, its subtree is not destroyed, and its local context
-   * survives. Used by createUnique to keep a moving instance's scope alive;
-   * only an explicit dispose() (which clears the protection) tears it down.
-   */
-  #disposeProtected = false;
+  /** @type {EffectPhaseValue} */
+  #phase;
+  #retained;
   localContext = Cell.context();
   /** @type {Renderer<any>} | undefined */
   renderer = getActiveRenderer();
+
+  /** @param {LifecycleMode} [lifecycle] */
+  constructor(lifecycle = 'normal') {
+    this.#phase =
+      lifecycle === 'deferred' ? EffectPhase.Deferred : EffectPhase.Blocked;
+    this.#retained = lifecycle === 'retained';
+  }
 
   /** The hierarchical ID of this node (e.g., "0.1.2") */
   get id() {
     return this.#id;
   }
 
-  enable() {
+  #enableSubtree() {
     const { capabilities } = this.renderer ?? {};
     if (
-      !capabilities?.supportsSetupEffects &&
-      !capabilities?.supportsConnectedCallbacks
+      this.#phase === EffectPhase.Orphaned ||
+      this.#phase === EffectPhase.Deferred ||
+      (!capabilities?.supportsSetupEffects &&
+        !capabilities?.supportsConnectedCallbacks)
     ) {
       return;
     }
 
-    this.#enabled = true;
-    for (const child of this.#children) {
-      if (!child.#suspended) child.enable();
+    if (this.#phase === EffectPhase.Blocked) {
+      this.#phase = EffectPhase.Eligible;
     }
+    for (const child of this.#children) child.#enableSubtree();
   }
 
-  suspend() {
-    this.#suspended = true;
-  }
-
-  unsuspend() {
-    this.#suspended = false;
-  }
-
-  disable() {
-    this.#enabled = false;
-    for (const child of this.#children) child.disable();
-  }
-
-  /**
-   * Marks this node so a parent's dispose cascade has no effect on it — its
-   * cleanups are deferred, its subtree is not destroyed, and its local
-   * context survives. The node is still torn down by an explicit dispose().
-   */
-  protectFromDispose() {
-    this.#disposeProtected = true;
+  #canActivate() {
+    return (
+      this.#phase === EffectPhase.Eligible || this.#phase === EffectPhase.Active
+    );
   }
 
   /** @param {SetupFn} effect  */
@@ -224,7 +220,8 @@ class EffectNode {
       if (next === null || renderer.isActive(next)) return;
 
       queueMicrotask(() => {
-        if (!this.#enabled || !this.#connectedEffects.includes(effect)) return;
+        if (!this.#canActivate() || !this.#connectedEffects.includes(effect))
+          return;
         if (effect.current === undefined) effect.current = null;
         updateConnectedEffect(effect, effect.ref.peek());
       });
@@ -237,21 +234,23 @@ class EffectNode {
       updateConnectedEffect(effect, effect.ref.peek());
     }
     for (const child of this.#children) {
-      if (child.#enabled && !child.#suspended)
-        child.#activateConnectedEffects();
+      if (child.#canActivate()) child.#activateConnectedEffects();
     }
   }
 
-  branch() {
-    const newNode = new EffectNode();
-    newNode.#enabled = this.#enabled;
+  /** @param {LifecycleMode} [lifecycle] */
+  branch(lifecycle = 'normal') {
+    const newNode = new EffectNode(lifecycle);
+    if (lifecycle !== 'deferred' && this.#canActivate()) {
+      newNode.#phase = EffectPhase.Eligible;
+    }
     newNode.#id = `${this.#id}.${this.#children.length}`;
     this.#children.push(newNode);
     return newNode;
   }
 
-  async #runActivateFns() {
-    if (!this.#enabled || this.#active) return;
+  async #runSetupFns() {
+    if (this.#phase !== EffectPhase.Eligible) return;
     for (const effect of this.#setupFns) {
       try {
         const cleanup = await effect();
@@ -260,58 +259,54 @@ class EffectNode {
         console.error(error);
       }
     }
-    this.#active = true;
-    const promises = [];
-    for (const child of this.#children) {
-      if (!child.#enabled || child.#suspended || child.#active) continue;
-      promises.push(child.#runActivateFns());
-    }
-    await Promise.all(promises);
+    this.#phase = EffectPhase.Active;
+    await Promise.all(
+      this.#children
+        .filter((child) => child.#phase === EffectPhase.Eligible)
+        .map((child) => child.#runSetupFns())
+    );
   }
 
   async activate() {
-    if (!this.#enabled) return;
+    if (this.#phase === EffectPhase.Deferred) {
+      this.#phase = EffectPhase.Blocked;
+      this.#enableSubtree();
+    }
+    if (!this.#canActivate()) return;
     this.#activateConnectedEffects();
-    if (this.#active) return;
+    if (this.#phase === EffectPhase.Active) return;
     await new Promise((resolve) => {
       queueMicrotask(() => resolve(undefined));
     });
-    await this.#runActivateFns();
+    await this.#runSetupFns();
     this.renderer?.host.dispatchEvent(new Event('retend:activate'));
   }
 
-  #runDisposeFns() {
-    if (!this.#enabled && this.#active) return false;
-    // A preserved node (e.g. a Unique being moved) must not run its cleanups
-    // either: the cascade reaching it is a location teardown, not the end of
-    // its journey. An explicit dispose() clears the protection first.
-    if (this.#disposeProtected) return false;
+  /** @param {boolean} cascading */
+  #runDisposeFns(cascading) {
+    if (cascading && this.#retained) return;
     for (const effect of this.#disposeFns) runCleanup(effect);
-    this.#active = false;
-    for (const child of this.#children) child.#runDisposeFns();
+    if (cascading) this.#phase = EffectPhase.Orphaned;
+    else if (this.#phase === EffectPhase.Active) {
+      this.#phase = EffectPhase.Eligible;
+    }
+    for (const child of this.#children) child.#runDisposeFns(true);
     this.localContext.destroy();
-    return true;
   }
 
-  #runConnectedDisposeFns() {
+  /** @param {boolean} cascading */
+  #runConnectedDisposeFns(cascading) {
+    if (cascading && this.#retained) return;
     for (const effect of this.#connectedEffects) {
       unmountConnectedEffect(effect);
     }
     this.#connectedEffects.length = 0;
-    for (const child of this.#children) child.#runConnectedDisposeFns();
+    for (const child of this.#children) child.#runConnectedDisposeFns(true);
   }
 
   dispose() {
-    this.#disposeProtected = false;
-    if (!this.#runDisposeFns()) return;
-    this.#runConnectedDisposeFns();
-
-    for (const child of this.#children) {
-      // prevents any side effects from being triggered in the
-      // (soon to be) orphaned subtrees, when any of their control
-      // structures receives changes.
-      child.disable();
-    }
+    this.#runDisposeFns(false);
+    this.#runConnectedDisposeFns(false);
 
     this.#setupFns.length = 0;
     this.#disposeFns.length = 0;
@@ -320,7 +315,11 @@ class EffectNode {
   }
 }
 
-class RootEffectNode extends EffectNode {}
+class RootEffectNode extends EffectNode {
+  constructor() {
+    super('deferred');
+  }
+}
 
 const SNAPSHOT_KEY = Symbol('__ACTIVE_SCOPE_SNAPSHOT__');
 
@@ -457,10 +456,13 @@ export class MissingScopeError extends Error {
  * effect lifecycle node to the currently active node tree.
  *
  * This function is used to create an isolated execution branch for components,
- * which can then be resumed or isolated using `withState`. Because
+ * which can then be restored or isolated using `withState`. Because
  * this eagerly branches the effect lifecycle tree, the newly created nodes
  * should eventually be activated or disposed to avoid memory leaks.
  *
+ * @param {LifecycleMode} [lifecycle='normal'] The lifecycle behavior for the branch:
+ *   `deferred` ignores ancestor activation until activated directly, while
+ *   `retained` ignores ancestor disposal until explicitly disposed.
  * @returns {StateSnapshot} A state branch containing the current scope chain and a newly forked effect node.
  *
  * @example
@@ -479,9 +481,9 @@ export class MissingScopeError extends Error {
  * });
  * ```
  */
-export function branchState() {
+export function branchState(lifecycle = 'normal') {
   const { scopes, node } = getState();
-  const branched = node.branch();
+  const branched = node.branch(lifecycle);
   return {
     scopes,
     node: branched,
@@ -673,7 +675,6 @@ export async function runPendingSetupEffects() {
       'runPendingSetupEffects() can only be called at the root level of a component tree.';
     throw new Error(message);
   }
-  node.enable();
   await node.activate();
   await new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
 }

--- a/packages/retend/source/library/scope.js
+++ b/packages/retend/source/library/scope.js
@@ -382,7 +382,7 @@ export function createScope(name) {
   });
 
   /// @ts-expect-error: Vite types are not ingrained.
-  if (import.meta.env?.DEV) {
+  if (import.meta.hot) {
     /// @ts-expect-error: Not used in production.
     Scope.Provider.__isScopeProviderOf = Scope;
   }
@@ -413,7 +413,7 @@ export function useScopeContext(Scope) {
 
   if (!relatedScopeData) {
     // @ts-expect-error: Vite types is not ingrained.
-    if (import.meta.env?.DEV) {
+    if (import.meta.hot) {
       // In HMR, scopes can change referential identity.
       // `HmrId` helps identify them across reloads.
       // Its not fool proof, but it works.

--- a/packages/retend/source/library/switch.js
+++ b/packages/retend/source/library/switch.js
@@ -3,6 +3,7 @@
 import { Cell, AsyncCell } from '@adbl/cells';
 
 import { useAwait } from './await.js';
+import { useFragmentCtx } from './fragment.js';
 import { getActiveRenderer } from './renderer.js';
 import { branchState, withState } from './scope.js';
 
@@ -34,6 +35,7 @@ function createSwitch(value, cases, defaultCase, key) {
 
     const snapshot = branchState();
     if (value instanceof AsyncCell) useAwait()?.waitUntil(value);
+    const fragmentCtx = useFragmentCtx();
 
     /** @param {any} current */
     const callback = (current) =>
@@ -45,7 +47,9 @@ function createSwitch(value, cases, defaultCase, key) {
     /** @param {any} nextValue */
     const processValueChange = (nextValue) => {
       snapshot.node.dispose();
-      renderer.write(handle, callback(nextValue));
+      const nextNodes = callback(nextValue);
+      fragmentCtx?.correlate(group, nextNodes, handle);
+      renderer.write(handle, nextNodes);
       snapshot.node.activate();
     };
 
@@ -63,7 +67,9 @@ function createSwitch(value, cases, defaultCase, key) {
       initialValue.then(processValueChange);
       return group;
     }
-    renderer.write(handle, callback(initialValue));
+    const nodes = callback(initialValue);
+    fragmentCtx?.correlate(group, nodes, handle);
+    renderer.write(handle, nodes);
     return group;
   };
 }

--- a/packages/retend/source/library/unique.js
+++ b/packages/retend/source/library/unique.js
@@ -200,12 +200,10 @@ export function createUnique(renderFn) {
     const handle = renderer.createGroupHandle(group);
 
     if (!instance) {
-      const state = branchState();
-      // Preserve this instance's scope (listeners and derived cells) when it
-      // moves between locations: a location's dispose cascade will not run
-      // its cleanups, destroy its subtree, or kill its local context. The
-      // node is still torn down explicitly once its journey ends.
-      state.node.protectFromDispose();
+      // A Unique instance owns its lifecycle independently of every location
+      // it visits. Location teardown leaves it alive; journey teardown calls
+      // dispose() on this retained branch directly.
+      const state = branchState('retained');
       state.data = { handle };
       const moveFns = new Set();
       /** @type {UniqueCtx} */
@@ -367,7 +365,6 @@ export function createUnique(renderFn) {
       return () => {
         const hmrContext = __HMR_SYMBOLS.getHMRContext();
         if (hmrContext?.current) {
-          instance.state.node.enable();
           instance.state.node.dispose();
           instances.delete(key);
           return;
@@ -389,7 +386,6 @@ export function createUnique(renderFn) {
           if (instance.journey.length == 0) {
             // The Unique component's journey has ended, there are no more handles.
             // Restoring to nothing helps flush the renderer state.
-            instance.state.node.enable(); // needed for dispose()
             instance.state.node.dispose();
             if (instance.idOfLastSavedHandle !== null) {
               renderer.restore(instance.idOfLastSavedHandle, null);

--- a/packages/retend/source/library/unique.js
+++ b/packages/retend/source/library/unique.js
@@ -2,10 +2,10 @@
 /** @import { SourceCell } from '@adbl/cells' */
 /** @import { StateSnapshot, Scope } from '../library/scope.js' */
 /** @import { Renderer } from '../library/renderer.js' */
+/** @import { FragmentContext } from './fragment.js' */
 
 import { Cell } from '@adbl/cells';
 
-import { createGroupFromNodes } from '../_internals.js';
 import { getGlobalContext } from '../context/index.js';
 import {
   __HMR_SYMBOLS,
@@ -17,6 +17,7 @@ import {
   withState,
 } from '../library/scope.js';
 import { useAwait } from './await.js';
+import { correlate, TrackedFragmentScope } from './fragment.js';
 
 const StashSymbol = Symbol('UniqueStash');
 /** @type {Scope<Set<UniqueMoveFn>>} */
@@ -30,9 +31,11 @@ const UniqueScope = createScope('Unique');
  * @typedef UniqueCtx
  * @property {SourceCell<UniqueProps<any>>} props
  * @property {StateSnapshot} state
+ * @property {unknown[]} logicalNodes
  * @property {Set<UniqueMoveFn>} moveFns
  * @property {Array<() => void>} restoreFns
- * @property {Array<[any, UniqueProps<any>]>} journey
+ * @property {Array<[any, any, UniqueProps<any>]>} journey
+ * Handle, group and props corresponding to a point in the journey
  * @property {ReturnType<typeof useAwait>} pendingAwait
  * @property {(() => void) | undefined} render
  * @property {boolean} isStable
@@ -191,6 +194,7 @@ export function createUnique(renderFn) {
     if (!instances) stash.set(renderer, (instances = new Map()));
 
     let instance = instances.get(key);
+    /** @type {any} */
     let group;
     /** @type {any} */
     let handle;
@@ -202,8 +206,26 @@ export function createUnique(renderFn) {
       const state = branchState();
       state.data = { handle };
       const moveFns = new Set();
+      /** @type {FragmentContext} */
+      const trackedFragmentProviderProps = {
+        correlate(group, nodes, handle) {
+          // The reasoning for this is to allow the reactive primitives within the
+          // Unique.Content to still be correlated globally, even if the Unique itself is not
+          // inside a TrackedFragmentScope, for the case where it could later move into one.
+          // The alternative would be to always correlate reactive groups regardless of whether
+          // they are inside a TrackedFragmentScope or not, which would be less efficient.
+          correlate(group, nodes, renderer, handle);
+        },
+      };
       const providerProps = [
-        { value: moveFns, children: () => renderFn(newInstance.props) },
+        {
+          value: moveFns,
+          children: () =>
+            TrackedFragmentScope.Provider({
+              value: trackedFragmentProviderProps,
+              children: () => renderFn(newInstance.props),
+            }),
+        },
       ];
       const props = withState(state, () => Cell.source(nextProps));
 
@@ -211,9 +233,10 @@ export function createUnique(renderFn) {
       const newInstance = {
         props,
         state,
+        logicalNodes: [],
         moveFns,
         restoreFns: [],
-        journey: [[handle, nextProps]],
+        journey: [[handle, group, nextProps]],
         pendingAwait: awaitCtx,
         render() {
           const pendingAwait = newInstance.pendingAwait;
@@ -229,17 +252,18 @@ export function createUnique(renderFn) {
               state.node.dispose();
               return;
             }
-            const content = createGroupFromNodes(
-              withState(state, () =>
-                renderer.handleComponent(
-                  UniqueScope.Provider,
-                  providerProps,
-                  state
-                )
-              ),
-              renderer
+            const Provider = UniqueScope.Provider;
+            const raw = withState(state, () =>
+              renderer.handleComponent(Provider, providerProps, state)
             );
-            renderer.write(state.data.handle, renderer.unwrapGroup(content));
+            const logicalNodes = Array.isArray(raw) ? raw : raw ? [raw] : [];
+            // Checking the last handle/group helps us avoid a scenario where a pending instance point
+            // is dropped before it can be resolved, or another instance point supercedes it
+            const [currentHandle, currentGroup] =
+              newInstance.journey[newInstance.journey.length - 1];
+            newInstance.logicalNodes = logicalNodes;
+            correlate(currentGroup, logicalNodes, renderer, currentHandle);
+            renderer.write(currentHandle, logicalNodes);
             newInstance.render = undefined;
           };
           if (pendingAwait && !pendingAwait.done)
@@ -264,12 +288,12 @@ export function createUnique(renderFn) {
         const instance = instances.get(key);
         if (!instance) return;
 
+        const previousPoint = instance.journey[instance.journey.length - 1];
+        const [previousHandle, previousGroup] = previousPoint;
         if (length !== instance.journey.length || !instance.isStable) {
           // Next instance, when last instance is not yet stable.
           // Move the nodes, but do not run move effects.
-          const previousHandle =
-            instance.journey[instance.journey.length - 1][0];
-          instance.journey.push([handle, nextProps]);
+          instance.journey.push([handle, group, nextProps]);
           instance.idOfLastSavedHandle = renderer.save(previousHandle);
           renderer.restore(instance.idOfLastSavedHandle, handle);
           instance.idOfLastSavedHandle = null;
@@ -281,7 +305,7 @@ export function createUnique(renderFn) {
           // active instance however, we need to run both save() and restore()
           // on the fly.
           instance.idOfLastSavedHandle = save(instance, renderer);
-          instance.journey.push([handle, nextProps]);
+          instance.journey.push([handle, group, nextProps]);
           renderer.restore(instance.idOfLastSavedHandle, handle);
           instance.idOfLastSavedHandle = null;
           // Yes this is not ideal, but abeg.
@@ -292,9 +316,15 @@ export function createUnique(renderFn) {
           // This is the best we can do without a major rearchitect.
           queueMicrotask(() => runRestoreFns(instance));
         }
+        // The nodes physically left the previous group, so it now contains
+        // nothing — update its correlation (and the old handle's) to match.
+        correlate(previousGroup, [], renderer, previousHandle);
+        // The moved nodes are the same ones, so the new group maps to the
+        // last committed logical nodes.
+        correlate(group, instance.logicalNodes, renderer, handle);
       };
       if (instance.render) {
-        instance.journey = [[handle, nextProps]];
+        instance.journey = [[handle, group, nextProps]];
         /** @type {{ handle: any }} */ (instance.state.data).handle = handle;
         instance.pendingAwait = awaitCtx;
         instance.render();
@@ -329,7 +359,11 @@ export function createUnique(renderFn) {
 
         const teardown = () => {
           const index = instance.journey.findIndex(([item]) => item === handle);
-          if (index !== -1) instance.journey.splice(index, 1);
+          if (index !== -1) {
+            const [removed] = instance.journey.splice(index, 1);
+            const removedGroup = removed[1];
+            correlate(removedGroup, [], renderer, handle);
+          }
 
           if (instance.journey.length == 0) {
             // The Unique component's journey has ended, there are no more handles.
@@ -343,11 +377,12 @@ export function createUnique(renderFn) {
             instances.delete(key);
           } else {
             // There is no forward handle to restore, so we restore to the last one in the journey.
-            const [last, lastProps] =
+            const [lastHandle, lastGroup, lastProps] =
               instance.journey[instance.journey.length - 1];
             if (isLastHandle && instance.idOfLastSavedHandle !== null) {
               instance.props.set(lastProps);
-              renderer.restore(instance.idOfLastSavedHandle, last);
+              correlate(lastGroup, instance.logicalNodes, renderer, lastHandle);
+              renderer.restore(instance.idOfLastSavedHandle, lastHandle);
               runRestoreFns(instance);
               // Reset to indicate the saved state has been used and we're ready
               // for a new save cycle. This allows save() to call moveFns in

--- a/packages/retend/source/library/unique.js
+++ b/packages/retend/source/library/unique.js
@@ -17,7 +17,7 @@ import {
   withState,
 } from '../library/scope.js';
 import { useAwait } from './await.js';
-import { correlate, TrackedFragmentScope } from './fragment.js';
+import { correlate, TrackedFragmentScope, useFragmentCtx } from './fragment.js';
 
 const StashSymbol = Symbol('UniqueStash');
 /** @type {Scope<Set<UniqueMoveFn>>} */
@@ -34,8 +34,8 @@ const UniqueScope = createScope('Unique');
  * @property {unknown[]} logicalNodes
  * @property {Set<UniqueMoveFn>} moveFns
  * @property {Array<() => void>} restoreFns
- * @property {Array<[any, any, UniqueProps<any>]>} journey
- * Handle, group and props corresponding to a point in the journey
+ * @property {Array<[any, any, UniqueProps<any>, FragmentContext | null]>} journey
+ * Handle, group, props and fragment context corresponding to a point in the journey
  * @property {ReturnType<typeof useAwait>} pendingAwait
  * @property {(() => void) | undefined} render
  * @property {boolean} isStable
@@ -194,18 +194,34 @@ export function createUnique(renderFn) {
     if (!instances) stash.set(renderer, (instances = new Map()));
 
     let instance = instances.get(key);
-    /** @type {any} */
-    let group;
-    /** @type {any} */
-    let handle;
+    /** @type {FragmentContext | null} */
+    const fragmentCtx = useFragmentCtx();
+    const group = renderer.createGroup();
+    const handle = renderer.createGroupHandle(group);
 
     if (!instance) {
-      // First Instance of createUnique, create normally.
-      group = renderer.createGroup();
-      handle = renderer.createGroupHandle(group);
       const state = branchState();
+      // Preserve this instance's scope (listeners and derived cells) when it
+      // moves between locations: a location's dispose cascade will not run
+      // its cleanups, destroy its subtree, or kill its local context. The
+      // node is still torn down explicitly once its journey ends.
+      state.node.protectFromDispose();
       state.data = { handle };
       const moveFns = new Set();
+      /** @type {UniqueCtx} */
+      let newInstance;
+      /**
+       * The fragment context of the location the instance is currently rendered
+       * at (the last point in its journey). This is resolved at call time because
+       * the provider is shared across every location the instance visits, so the
+       * enclosing fragment can change between points.
+       * @returns {FragmentContext | null}
+       */
+      const getActiveFragmentCtx = () => {
+        const journey = newInstance?.journey;
+        if (!journey || journey.length === 0) return null;
+        return journey[journey.length - 1][3] ?? null;
+      };
       /** @type {FragmentContext} */
       const trackedFragmentProviderProps = {
         correlate(group, nodes, handle) {
@@ -215,6 +231,12 @@ export function createUnique(renderFn) {
           // The alternative would be to always correlate reactive groups regardless of whether
           // they are inside a TrackedFragmentScope or not, which would be less efficient.
           correlate(group, nodes, renderer, handle);
+          // Re-resolve the enclosing fragment's ref so it tracks nodes that
+          // changed inside the Unique (e.g. a reactive If switching branches).
+          getActiveFragmentCtx()?.invalidate();
+        },
+        invalidate() {
+          getActiveFragmentCtx()?.invalidate();
         },
       };
       const providerProps = [
@@ -230,13 +252,13 @@ export function createUnique(renderFn) {
       const props = withState(state, () => Cell.source(nextProps));
 
       /** @type {UniqueCtx} */
-      const newInstance = {
+      newInstance = {
         props,
         state,
         logicalNodes: [],
         moveFns,
         restoreFns: [],
-        journey: [[handle, group, nextProps]],
+        journey: [[handle, group, nextProps, fragmentCtx]],
         pendingAwait: awaitCtx,
         render() {
           const pendingAwait = newInstance.pendingAwait;
@@ -263,6 +285,9 @@ export function createUnique(renderFn) {
               newInstance.journey[newInstance.journey.length - 1];
             newInstance.logicalNodes = logicalNodes;
             correlate(currentGroup, logicalNodes, renderer, currentHandle);
+            // The stash now reflects the freshly committed nodes, so re-resolve
+            // any enclosing fragment refs that include this instance.
+            getActiveFragmentCtx()?.invalidate();
             renderer.write(currentHandle, logicalNodes);
             newInstance.render = undefined;
           };
@@ -277,8 +302,6 @@ export function createUnique(renderFn) {
       instances.set(key, newInstance);
       newInstance.render?.();
     } else {
-      group = renderer.createGroup();
-      handle = renderer.createGroupHandle(group);
       instance.props.set(nextProps);
 
       // In the case where there are multiple awaiting instances, we
@@ -293,7 +316,7 @@ export function createUnique(renderFn) {
         if (length !== instance.journey.length || !instance.isStable) {
           // Next instance, when last instance is not yet stable.
           // Move the nodes, but do not run move effects.
-          instance.journey.push([handle, group, nextProps]);
+          instance.journey.push([handle, group, nextProps, fragmentCtx]);
           instance.idOfLastSavedHandle = renderer.save(previousHandle);
           renderer.restore(instance.idOfLastSavedHandle, handle);
           instance.idOfLastSavedHandle = null;
@@ -305,7 +328,7 @@ export function createUnique(renderFn) {
           // active instance however, we need to run both save() and restore()
           // on the fly.
           instance.idOfLastSavedHandle = save(instance, renderer);
-          instance.journey.push([handle, group, nextProps]);
+          instance.journey.push([handle, group, nextProps, fragmentCtx]);
           renderer.restore(instance.idOfLastSavedHandle, handle);
           instance.idOfLastSavedHandle = null;
           // Yes this is not ideal, but abeg.
@@ -319,12 +342,14 @@ export function createUnique(renderFn) {
         // The nodes physically left the previous group, so it now contains
         // nothing — update its correlation (and the old handle's) to match.
         correlate(previousGroup, [], renderer, previousHandle);
+        previousPoint[3]?.invalidate();
         // The moved nodes are the same ones, so the new group maps to the
         // last committed logical nodes.
         correlate(group, instance.logicalNodes, renderer, handle);
+        fragmentCtx?.invalidate();
       };
       if (instance.render) {
-        instance.journey = [[handle, group, nextProps]];
+        instance.journey = [[handle, group, nextProps, fragmentCtx]];
         /** @type {{ handle: any }} */ (instance.state.data).handle = handle;
         instance.pendingAwait = awaitCtx;
         instance.render();
@@ -347,13 +372,9 @@ export function createUnique(renderFn) {
           instances.delete(key);
           return;
         }
-        // This detaches it from the parent node, preventing
-        // dispose() from cascading, and keeping its context alive
-        // when moved.
         const isLastHandle =
           instance.journey[instance.journey.length - 1][0] === handle;
         if (isLastHandle) {
-          instance.state.node.disable();
           instance.idOfLastSavedHandle = save(instance, renderer);
         }
 
@@ -377,12 +398,13 @@ export function createUnique(renderFn) {
             instances.delete(key);
           } else {
             // There is no forward handle to restore, so we restore to the last one in the journey.
-            const [lastHandle, lastGroup, lastProps] =
+            const [lastHandle, lastGroup, lastProps, lastFragmentCtx] =
               instance.journey[instance.journey.length - 1];
             if (isLastHandle && instance.idOfLastSavedHandle !== null) {
               instance.props.set(lastProps);
               correlate(lastGroup, instance.logicalNodes, renderer, lastHandle);
               renderer.restore(instance.idOfLastSavedHandle, lastHandle);
+              lastFragmentCtx?.invalidate();
               runRestoreFns(instance);
               // Reset to indicate the saved state has been used and we're ready
               // for a new save cycle. This allows save() to call moveFns in

--- a/packages/retend/source/library/utils.js
+++ b/packages/retend/source/library/utils.js
@@ -2,6 +2,7 @@
 import { AsyncCell, Cell } from '@adbl/cells';
 
 import { Block } from './block.js';
+import { useFragmentCtx } from './fragment.js';
 import { useAwait } from './index.js';
 
 /**
@@ -121,6 +122,8 @@ export function normalizeJsxChild(child, renderer) {
       stack.push(child[i]);
     }
 
+    /** @type {any[]} */
+    const collected = [];
     while (stack.length > 0) {
       const subchild = stack.pop();
       if (Array.isArray(subchild)) {
@@ -131,10 +134,12 @@ export function normalizeJsxChild(child, renderer) {
       }
 
       if (subchild instanceof Block) {
-        renderer.append(
-          group,
-          normalizeJsxChild(subchild.instantiate(renderer), renderer)
+        const normalized = normalizeJsxChild(
+          subchild.instantiate(renderer),
+          renderer
         );
+        collected.push(normalized);
+        renderer.append(group, normalized);
         continue;
       }
 
@@ -152,8 +157,10 @@ export function normalizeJsxChild(child, renderer) {
         normalized = createTextNode(subchild, renderer);
       }
 
+      collected.push(normalized);
       renderer.append(group, normalized);
     }
+    useFragmentCtx()?.correlate(group, collected);
     return group;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
   packages/retend:
     dependencies:
       '@adbl/cells':
-        specifier: ^0.0.26
-        version: 0.0.26
+        specifier: ^0.0.27
+        version: 0.0.27
       csstype:
         specifier: ^3.2.3
         version: 3.2.3
@@ -361,8 +361,8 @@ importers:
 
 packages:
 
-  '@adbl/cells@0.0.26':
-    resolution: {integrity: sha512-rgv0o33KbZEQ3kKe/GLcISPDbNbs8oD0P8fNHNdBcnPn8WUvc8pZSdCb81aWAaXlhGFliHKsMFlDZ2F1CuqpMg==}
+  '@adbl/cells@0.0.27':
+    resolution: {integrity: sha512-tjIUhieJJe1nctk9q3qs3HHUHKMEGw5dtVGufI+i4rmmViaJ+WR44NnfwJdIEG9lBTsWd8NKea6UFfE5VrU5/A==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4391,7 +4391,7 @@ packages:
 
 snapshots:
 
-  '@adbl/cells@0.0.26': {}
+  '@adbl/cells@0.0.27': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/tests/fragment-refs/await-refs.spec.tsx
+++ b/tests/fragment-refs/await-refs.spec.tsx
@@ -1,0 +1,140 @@
+import { Await, Cell, For, Fragment, getActiveRenderer } from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const pendingText = () =>
+  Cell.derivedAsync(() => new Promise<string>(() => undefined));
+
+const runTests = () => {
+  it('should expose the initial Await fallback', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const pending = pendingText();
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await fallback={<span>Loading</span>}>
+          <div>{pending}</div>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('Loading');
+  });
+
+  it('should collect multiple nodes from an Await fallback fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const pending = pendingText();
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await
+          fallback={
+            <>
+              <span>A</span>
+              <span>B</span>
+            </>
+          }
+        >
+          <div>{pending}</div>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+    ]);
+  });
+
+  it('should expose text from an Await fallback', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const pending = pendingText();
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await fallback="Loading text">
+          <div>{pending}</div>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect((nodes![0] as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect((nodes![0] as Node).textContent).toBe('Loading text');
+  });
+
+  it('should keep document order across mixed Await fallback content', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const pending = pendingText();
+    const App = () => (
+      <Fragment ref={ref}>
+        <div>head</div>
+        <Await
+          fallback={
+            <>
+              <b>A</b>
+              {'-'}
+              <i>B</i>
+            </>
+          }
+        >
+          <div>{pending}</div>
+        </Await>
+        <div>tail</div>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'A',
+      '-',
+      'B',
+      'tail',
+    ]);
+  });
+
+  it('should unwrap a For rendered in the initial Await fallback', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const pending = pendingText();
+    const items = Cell.source(['a', 'b']);
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await
+          fallback={For(items, (item) => (
+            <li>{item}</li>
+          ))}
+        >
+          <div>{pending}</div>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+};
+
+describe('Await Block Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/fragment-refs/await-refs.spec.tsx
+++ b/tests/fragment-refs/await-refs.spec.tsx
@@ -1,7 +1,13 @@
 import { Await, Cell, For, Fragment, getActiveRenderer } from 'retend';
 import { describe, expect, it } from 'vitest';
 
-import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+import {
+  browserSetup,
+  textOf,
+  timeout,
+  vDomSetup,
+  type NodeLike,
+} from '../setup.tsx';
 
 const pendingText = () =>
   Cell.derivedAsync(() => new Promise<string>(() => undefined));
@@ -123,6 +129,76 @@ const runTests = () => {
     expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
       'a',
       'b',
+    ]);
+  });
+
+  it('should update the ref when Await finishes rendering its content', async () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    let resolvePending!: (value: string) => void;
+    const pending = Cell.derivedAsync(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePending = resolve;
+        })
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await fallback={<span>Loading</span>}>
+          <div>{pending}</div>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'Loading',
+    ]);
+
+    resolvePending('Ready');
+    await timeout();
+
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'Ready',
+    ]);
+  });
+
+  it('should update the ref when a nested Await finishes rendering', async () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    let resolveInner!: (value: string) => void;
+    const inner = Cell.derivedAsync(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveInner = resolve;
+        })
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        <Await fallback={<span>OuterLoading</span>}>
+          <Await fallback={<span>InnerLoading</span>}>
+            <div>{inner}</div>
+          </Await>
+        </Await>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    // The outer Await has no async dependency of its own, so it resolves
+    // independently and reveals the inner Await's fallback.
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'OuterLoading',
+    ]);
+
+    await timeout();
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'InnerLoading',
+    ]);
+
+    resolveInner('Ready');
+    await timeout();
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'Ready',
     ]);
   });
 };

--- a/tests/fragment-refs/for-refs.spec.tsx
+++ b/tests/fragment-refs/for-refs.spec.tsx
@@ -1,0 +1,235 @@
+import { Cell, For, Fragment, If, getActiveRenderer } from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const runTests = () => {
+  it('should expose static For items in document order alongside siblings', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = ['a', 'b', 'c'];
+    const App = () => (
+      <Fragment ref={ref}>
+        <div>head</div>
+        {For(items, (item) => (
+          <li>{item}</li>
+        ))}
+        <div>tail</div>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'a',
+      'b',
+      'c',
+      'tail',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should expose the items of a reactive For in order', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source(['a', 'b', 'c']);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) => (
+          <li>{item}</li>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should contribute nothing for an empty reactive For', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source<string[]>([]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) => (
+          <li>{item}</li>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()).toEqual([]);
+  });
+
+  it('should expose For items keyed by a property', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(
+          items,
+          (item) => (
+            <li>{item.label}</li>
+          ),
+          { key: 'id' }
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['A', 'B']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should flatten fragment-returning For items in order', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source(['a', 'b']);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) => (
+          <>
+            <span>{item}</span>
+            <span>-</span>
+          </>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      '-',
+      'b',
+      '-',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should expose only the active items when For items contain an If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { name: 'a', active: true },
+      { name: 'b', active: false },
+      { name: 'c', active: true },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) => If(item.active, () => <li>{item.name}</li>))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['a', 'c']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should track text nodes returned by For items', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const items = Cell.source(['x', 'y']);
+    const App = () => (
+      <Fragment ref={ref}>{For(items, (item) => item)}</Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(2);
+    for (const node of nodes!) {
+      expect(node).not.toBeInstanceOf(renderer.host.HTMLElement);
+      expect((node as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    }
+    expect((nodes![0] as Node).textContent).toBe('x');
+    expect((nodes![1] as Node).textContent).toBe('y');
+  });
+
+  it('should expose component output per For item', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source(['x', 'y']);
+    const Item = ({ value }: { value: string }) => <li>{value}</li>;
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) => (
+          <Item value={item} />
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['x', 'y']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should unwrap nested For groups down to the items', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { name: 'a', children: Cell.source(['1', '2']) },
+      { name: 'b', children: Cell.source(['3']) },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(items, (item) =>
+          For(item.children, (child) => (
+            <li>
+              {item.name}
+              {child}
+            </li>
+          ))
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a1',
+      'a2',
+      'b3',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+};
+
+describe('For Block Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/fragment-refs/for-refs.spec.tsx
+++ b/tests/fragment-refs/for-refs.spec.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'retend/jsx-runtime';
+
 import { Cell, For, Fragment, If, getActiveRenderer } from 'retend';
 import { describe, expect, it } from 'vitest';
 
@@ -219,6 +221,205 @@ const runTests = () => {
     for (const node of nodes!) {
       expect(node).toBeInstanceOf(renderer.host.HTMLElement);
     }
+  });
+
+  it('should update the ref when a reactive For replaces its items', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(
+          items,
+          (item) => (
+            <li>{item.name}</li>
+          ),
+          { key: 'id' }
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+      'C',
+    ]);
+
+    items.set([
+      { id: 'x', name: 'X' },
+      { id: 'y', name: 'Y' },
+      { id: 'z', name: 'Z' },
+    ]);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'X',
+      'Y',
+      'Z',
+    ]);
+
+    items.set([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ]);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+      'C',
+    ]);
+  });
+
+  it('should update the ref to the new document order when a keyed reactive For is reordered', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(
+          items,
+          (item) => (
+            <li>{item.name}</li>
+          ),
+          { key: 'id' }
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const first = ref.get()!;
+    expect(first.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+      'C',
+    ]);
+
+    items.set([
+      { id: 'c', name: 'C' },
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]);
+    const second = ref.get()!;
+    expect(second.map((node) => textOf(node as NodeLike))).toEqual([
+      'C',
+      'A',
+      'B',
+    ]);
+    // Keyed For moves nodes rather than recreating them, so the ref keeps the
+    // same node identities and only their order changes.
+    expect(second[0]).toBe(first[2]);
+    expect(second[1]).toBe(first[0]);
+    expect(second[2]).toBe(first[1]);
+  });
+
+  it('should empty the ref when a reactive For becomes empty', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]);
+    const App = () => (
+      <Fragment ref={ref}>
+        {For(
+          items,
+          (item) => (
+            <li>{item.name}</li>
+          ),
+          { key: 'id' }
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+    ]);
+
+    items.set([]);
+    expect(ref.get()).toEqual([]);
+
+    items.set([{ id: 'a', name: 'A' }]);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual(['A']);
+  });
+
+  it('should expose a For forwarded through props.children into a Fragment ref', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]);
+    const List = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <List>
+        {For(
+          items,
+          (item) => (
+            <li>{item.name}</li>
+          ),
+          { key: 'id' }
+        )}
+      </List>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['A', 'B']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should update the ref when a For forwarded through props.children is reordered', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]);
+    const List = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <List>
+        {For(
+          items,
+          (item) => (
+            <li>{item.name}</li>
+          ),
+          { key: 'id' }
+        )}
+      </List>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'A',
+      'B',
+    ]);
+
+    items.set([
+      { id: 'b', name: 'B' },
+      { id: 'a', name: 'A' },
+    ]);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'B',
+      'A',
+    ]);
+
+    items.set([]);
+    expect(ref.get()).toEqual([]);
   });
 };
 

--- a/tests/fragment-refs/if-refs.spec.tsx
+++ b/tests/fragment-refs/if-refs.spec.tsx
@@ -1,0 +1,360 @@
+import type { JSX } from 'retend/jsx-runtime';
+
+import { Cell, For, Fragment, If, Switch, getActiveRenderer } from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const runTests = () => {
+  it('should expose the rendered branch of a reactive If (truthy)', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <div>yes</div>
+          ),
+          () => (
+            <span>no</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should expose the else branch of a reactive If (falsy)', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <div>yes</div>
+          ),
+          () => (
+            <span>no</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('no');
+  });
+
+  it('should contribute nothing for a falsy reactive If without an else branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <div>yes</div>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()).toEqual([]);
+  });
+
+  it('should expose the active branch of the object form of If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, {
+          true: () => <b>yes</b>,
+          false: () => <i>no</i>,
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should unwrap nested Ifs down to the innermost branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const outer = Cell.source(true);
+    const inner = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          outer,
+          () =>
+            If(
+              inner,
+              () => <b>both</b>,
+              () => <i>outer only</i>
+            ),
+          () => (
+            <span>neither</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('outer only');
+  });
+
+  it('should collect multiple nodes from an If branch returning a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <>
+            <b>1</b>
+            <b>2</b>
+          </>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['1', '2']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should keep document order across several reactive Ifs and static siblings', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const a = Cell.source(true);
+    const b = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        <div>head</div>
+        {If(a, () => (
+          <b>one</b>
+        ))}
+        {If(
+          b,
+          () => (
+            <i>two</i>
+          ),
+          () => (
+            <u>two-fallback</u>
+          )
+        )}
+        <div>tail</div>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'one',
+      'two-fallback',
+      'tail',
+    ]);
+  });
+
+  it('should track text nodes rendered by an If branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>{If(condition, () => 'plain text')}</Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).not.toBeInstanceOf(renderer.host.HTMLElement);
+    expect((nodes![0] as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect((nodes![0] as Node).textContent).toBe('plain text');
+  });
+
+  it('should forward through a referenced fragment nested inside an If branch', () => {
+    const renderer = getActiveRenderer();
+    const outerRef = Cell.source<HTMLElement[] | null>(null);
+    const innerRef = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={outerRef}>
+        {If(condition, () => (
+          <Fragment ref={innerRef}>
+            <div>inner</div>
+          </Fragment>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(outerRef.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'inner',
+    ]);
+    expect(innerRef.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'inner',
+    ]);
+  });
+
+  it('should expose the output of a component rendered by If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Item = () => <li>item</li>;
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <Item />
+          ),
+          () => (
+            <span>none</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('item');
+  });
+
+  it('should expose a component with children rendered by If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Box = (props: { children: JSX.Children }) => (
+      <div>{props.children}</div>
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <Box>
+            <span>a</span>
+            <span>b</span>
+          </Box>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('ab');
+  });
+
+  it('should expose the innermost branch when If renders a component that returns an If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const inner = Cell.source(false);
+    const Inner = ({ condition }: { condition: Cell<boolean> }) =>
+      If(
+        condition,
+        () => <b>yes</b>,
+        () => <i>no</i>
+      );
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <Inner condition={inner} />
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('no');
+  });
+
+  it('should expose the matched case when If renders a component that returns a Switch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const value = Cell.source('B' as 'A' | 'B');
+    const Status = () =>
+      Switch(value, {
+        A: () => <b>on</b>,
+        B: () => <i>off</i>,
+      });
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <Status />
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('off');
+  });
+
+  it('should expose the mapped items when If renders a component that returns a For', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const items = Cell.source(['a', 'b', 'c']);
+    const List = () => For(items, (item) => <li>{item}</li>);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <List />
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+};
+
+describe('If Block Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/fragment-refs/if-refs.spec.tsx
+++ b/tests/fragment-refs/if-refs.spec.tsx
@@ -345,6 +345,393 @@ const runTests = () => {
       expect(node).toBeInstanceOf(renderer.host.HTMLElement);
     }
   });
+
+  it('should update the ref when a reactive If switches branches', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <div>yes</div>
+          ),
+          () => (
+            <span>no</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual(['yes']);
+
+    condition.set(false);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('no');
+  });
+
+  it('should keep the ref in sync as a reactive If toggles back and forth', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <div>yes</div>
+          ),
+          () => (
+            <span>no</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('no');
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should empty the ref when a reactive If without an else branch turns falsy', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <div>yes</div>
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(ref.get()).toEqual([]);
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should update the ref for the object form of a reactive If', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, {
+          true: () => <b>yes</b>,
+          false: () => <i>no</i>,
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('no');
+  });
+
+  it('should update the ref through nested Ifs when either condition changes', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const outer = Cell.source(true);
+    const inner = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          outer,
+          () =>
+            If(
+              inner,
+              () => <b>both</b>,
+              () => <i>outer only</i>
+            ),
+          () => (
+            <span>neither</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('outer only');
+
+    inner.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('both');
+
+    outer.set(false);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('neither');
+  });
+
+  it('should update the ref to the full set of nodes of the new branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <>
+              <b>1</b>
+              <b>2</b>
+            </>
+          ),
+          () => (
+            <u>none</u>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      '1',
+      '2',
+    ]);
+
+    condition.set(false);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('none');
+
+    condition.set(true);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  it('should keep document order in the ref across updates of several reactive Ifs', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const a = Cell.source(true);
+    const b = Cell.source(false);
+    const App = () => (
+      <Fragment ref={ref}>
+        <div>head</div>
+        {If(a, () => (
+          <b>one</b>
+        ))}
+        {If(
+          b,
+          () => (
+            <i>two</i>
+          ),
+          () => (
+            <u>two-fallback</u>
+          )
+        )}
+        <div>tail</div>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'one',
+      'two-fallback',
+      'tail',
+    ]);
+
+    a.set(false);
+    b.set(true);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'two',
+      'tail',
+    ]);
+
+    a.set(true);
+    b.set(false);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'head',
+      'one',
+      'two-fallback',
+      'tail',
+    ]);
+  });
+
+  it('should update the ref when a reactive If swaps a component branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Item = () => <li>item</li>;
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => (
+            <Item />
+          ),
+          () => (
+            <span>none</span>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('item');
+
+    condition.set(false);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('none');
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('item');
+  });
+
+  it('should update the ref to text nodes produced by a reactive If branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const condition = Cell.source(true);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(
+          condition,
+          () => 'plain text',
+          () => 'fallback text'
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect((ref.get()![0] as Node).textContent).toBe('plain text');
+
+    condition.set(false);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect((nodes![0] as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect((nodes![0] as Node).textContent).toBe('fallback text');
+  });
+
+  it('should expose an If passed as props.children through a component wrapped by a Fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Card = (props: { children: JSX.Children }) => (
+      <div>{props.children}</div>
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        <Card>
+          {If(
+            condition,
+            () => (
+              <b>yes</b>
+            ),
+            () => (
+              <i>no</i>
+            )
+          )}
+        </Card>
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should expose an If forwarded through props.children into a Fragment ref', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Card = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <Card>
+        {If(
+          condition,
+          () => (
+            <b>yes</b>
+          ),
+          () => (
+            <i>no</i>
+          )
+        )}
+      </Card>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should update the ref when an If forwarded through props.children changes branches', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Card = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <Card>
+        {If(
+          condition,
+          () => (
+            <b>yes</b>
+          ),
+          () => (
+            <i>no</i>
+          )
+        )}
+      </Card>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(ref.get()).toHaveLength(1);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('no');
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should empty the ref when an If without an else forwarded through props.children turns falsy', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const Card = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <Card>
+        {If(condition, () => (
+          <b>yes</b>
+        ))}
+      </Card>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(ref.get()).toEqual([]);
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+  });
 };
 
 describe('If Block Fragment Refs', () => {

--- a/tests/fragment-refs/simple-refs.spec.tsx
+++ b/tests/fragment-refs/simple-refs.spec.tsx
@@ -1,0 +1,268 @@
+import type { JSX } from 'retend/jsx-runtime';
+
+import { Cell, Fragment, getActiveRenderer } from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const runTests = () => {
+  it('should track fragment refs with single element children', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return (
+        <Fragment ref={ref}>
+          <div>Hello, world!</div>
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toBeDefined();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+  });
+
+  it('should track forwarded fragment refs in props.children', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = (props: { children: JSX.Children }) => {
+      const { children } = props;
+      return <Fragment ref={ref}>{children}</Fragment>;
+    };
+
+    renderer.render(
+      <App>
+        <div>Hello, world!</div>
+      </App>
+    );
+    const nodes = ref.get();
+    expect(nodes).toBeDefined();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+  });
+
+  it('should track multiple element children in order', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return (
+        <Fragment ref={ref}>
+          <div>a</div>
+          <span>b</span>
+          <p>c</p>
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(3);
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should track text node children', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const App = () => {
+      return <Fragment ref={ref}>Hello</Fragment>;
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).not.toBeInstanceOf(renderer.host.HTMLElement);
+    expect((nodes![0] as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect((nodes![0] as Node).textContent).toBe('Hello');
+  });
+
+  it('should track mixed text and element children in order', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return (
+        <Fragment ref={ref}>
+          <div>a</div>
+          {'text'}
+          <span>b</span>
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(3);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('a');
+    expect(nodes![1].nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect(nodes![1].textContent).toBe('text');
+    expect(nodes![2]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![2] as NodeLike)).toBe('b');
+  });
+
+  it('should resolve empty fragments to an empty array', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return <Fragment ref={ref} />;
+    };
+
+    renderer.render(<App />);
+    expect(ref.get()).toEqual([]);
+  });
+
+  it('should resolve null children to an empty array', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return <Fragment ref={ref}>{null}</Fragment>;
+    };
+
+    renderer.render(<App />);
+    expect(ref.get()).toEqual([]);
+  });
+
+  it('should track nested fragments with separate refs', () => {
+    const renderer = getActiveRenderer();
+    const outerRef = Cell.source<HTMLElement[] | null>(null);
+    const innerRef = Cell.source<HTMLElement[] | null>(null);
+    const App = () => {
+      return (
+        <Fragment ref={outerRef}>
+          <div>outer</div>
+          <Fragment ref={innerRef}>
+            <span>inner</span>
+          </Fragment>
+          <p>tail</p>
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    expect(outerRef.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'outer',
+      'inner',
+      'tail',
+    ]);
+    expect(innerRef.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'inner',
+    ]);
+  });
+
+  it('should track component output inside a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const Item = () => {
+      return <li>item</li>;
+    };
+    const App = () => {
+      return (
+        <Fragment ref={ref}>
+          <Item />
+          <Item />
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(2);
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'item',
+      'item',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should flatten array children into the ref', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = [<div>1</div>, <div>2</div>, <div>3</div>];
+    const App = () => {
+      return <Fragment ref={ref}>{items}</Fragment>;
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(3);
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+  });
+
+  it('should re-evaluate plain conditional children on re-render', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const App = ({ show }: { show: boolean }) => {
+      return (
+        <Fragment ref={ref}>{show ? <div>yes</div> : <span>no</span>}</Fragment>
+      );
+    };
+
+    renderer.render(<App show={true} />);
+    const first = ref.get();
+    expect(first).toHaveLength(1);
+    expect(textOf(first![0] as NodeLike)).toBe('yes');
+
+    renderer.render(<App show={false} />);
+    const second = ref.get();
+    expect(second).toHaveLength(1);
+    expect(textOf(second![0] as NodeLike)).toBe('no');
+  });
+
+  it('should preserve document order across mixed content', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const Item = () => {
+      return <em>e</em>;
+    };
+    const App = () => {
+      return (
+        <Fragment ref={ref}>
+          <div>a</div>
+          {[<span>b</span>, <span>c</span>]}
+          {'text'}
+          <Item />
+          <Fragment>
+            <p>d</p>
+          </Fragment>
+        </Fragment>
+      );
+    };
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+      'c',
+      'text',
+      'e',
+      'd',
+    ]);
+  });
+};
+
+describe('Simple Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/fragment-refs/simple-refs.spec.tsx
+++ b/tests/fragment-refs/simple-refs.spec.tsx
@@ -1,7 +1,14 @@
 import type { JSX } from 'retend/jsx-runtime';
 
-import { Cell, Fragment, getActiveRenderer } from 'retend';
-import { describe, expect, it } from 'vitest';
+import {
+  Cell,
+  Fragment,
+  If,
+  getActiveRenderer,
+  getState,
+  onConnected,
+} from 'retend';
+import { describe, expect, it, vi } from 'vitest';
 
 import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
 
@@ -264,5 +271,53 @@ describe('Simple Fragment Refs', () => {
   describe('VDom', () => {
     vDomSetup();
     runTests();
+  });
+});
+
+describe('Simple Fragment Refs (Browser only)', () => {
+  browserSetup();
+
+  it('should fire onConnected and its cleanup when the first element of a fragment changes', async () => {
+    const renderer = getActiveRenderer();
+    const mounted = vi.fn();
+    const cleanup = vi.fn();
+    const condition = Cell.source(true);
+
+    const MyWrapper = (props: { children: JSX.Children }) => {
+      const ref = Cell.source<HTMLElement[] | null>(null);
+      const firstElementRef = Cell.derived(() => ref.get()?.[0] ?? null);
+      onConnected(firstElementRef, (el) => {
+        mounted(el);
+        return cleanup;
+      });
+      return <Fragment ref={ref}>{props.children}</Fragment>;
+    };
+
+    const App = () => (
+      <MyWrapper>
+        {If(
+          condition,
+          () => (
+            <div>yes</div>
+          ),
+          () => (
+            <span>no</span>
+          )
+        )}
+      </MyWrapper>
+    );
+
+    const result = renderer.render(<App />) as unknown as Node;
+    window.document.body.append(result);
+    await getState().node.activate();
+
+    expect(mounted).toHaveBeenCalledTimes(1);
+    expect(textOf(mounted.mock.calls[0][0] as NodeLike)).toBe('yes');
+    expect(cleanup).not.toHaveBeenCalled();
+
+    condition.set(false);
+    expect(mounted).toHaveBeenCalledTimes(2);
+    expect(textOf(mounted.mock.calls[1][0] as NodeLike)).toBe('no');
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/fragment-refs/switch-refs.spec.tsx
+++ b/tests/fragment-refs/switch-refs.spec.tsx
@@ -1,0 +1,127 @@
+import { Cell, Fragment, Switch, getActiveRenderer } from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const runTests = () => {
+  it('should expose the selected case of a reactive Switch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'b'>('b');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(value, {
+          a: () => <b>A</b>,
+          b: () => <i>B</i>,
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('B');
+  });
+
+  it('should expose the default case of a reactive Switch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'missing'>('missing');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(
+          value,
+          {
+            a: () => <b>A</b>,
+          },
+          () => (
+            <i>default</i>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('default');
+  });
+
+  it('should collect multiple nodes from a Switch case returning a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a'>('a');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(value, {
+          a: () => (
+            <>
+              <span>1</span>
+              <span>2</span>
+            </>
+          ),
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['1', '2']);
+  });
+
+  it('should expose text returned by a reactive Switch case', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<unknown[] | null>(null);
+    const value = Cell.source<'text'>('text');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(value, {
+          text: () => 'plain text',
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect((nodes![0] as Node).nodeType).toBe(renderer.host.Node.TEXT_NODE);
+    expect((nodes![0] as Node).textContent).toBe('plain text');
+  });
+
+  it('should unwrap a nested reactive Switch through a component', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const outer = Cell.source<'inner'>('inner');
+    const inner = Cell.source<'a' | 'b'>('b');
+    const Inner = () =>
+      Switch(inner, {
+        a: () => <b>A</b>,
+        b: () => <i>B</i>,
+      });
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(outer, {
+          inner: () => <Inner />,
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('B');
+  });
+};
+
+describe('Switch Block Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/fragment-refs/switch-refs.spec.tsx
+++ b/tests/fragment-refs/switch-refs.spec.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'retend/jsx-runtime';
+
 import { Cell, Fragment, Switch, getActiveRenderer } from 'retend';
 import { describe, expect, it } from 'vitest';
 
@@ -111,6 +113,109 @@ const runTests = () => {
     const nodes = ref.get();
     expect(nodes).toHaveLength(1);
     expect(textOf(nodes![0] as NodeLike)).toBe('B');
+  });
+
+  it('should update the ref when a reactive Switch changes cases', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'b'>('a');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(value, {
+          a: () => <b>A</b>,
+          b: () => <i>B</i>,
+        })}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
+
+    value.set('b');
+    expect(ref.get()).toHaveLength(1);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('B');
+
+    value.set('a');
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
+  });
+
+  it('should update the ref when a reactive Switch moves to the default case', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'missing'>('a');
+    const App = () => (
+      <Fragment ref={ref}>
+        {Switch(
+          value,
+          {
+            a: () => <b>A</b>,
+          },
+          () => (
+            <i>default</i>
+          )
+        )}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
+
+    value.set('missing');
+    expect(ref.get()).toHaveLength(1);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('default');
+
+    value.set('a');
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
+  });
+
+  it('should expose a Switch forwarded through props.children into a Fragment ref', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'b'>('b');
+    const Panel = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <Panel>
+        {Switch(value, {
+          a: () => <b>A</b>,
+          b: () => <i>B</i>,
+        })}
+      </Panel>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('B');
+  });
+
+  it('should update the ref when a Switch forwarded through props.children changes cases', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'b'>('a');
+    const Panel = (props: { children: JSX.Children }) => (
+      <Fragment ref={ref}>{props.children}</Fragment>
+    );
+    const App = () => (
+      <Panel>
+        {Switch(value, {
+          a: () => <b>A</b>,
+          b: () => <i>B</i>,
+        })}
+      </Panel>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
+
+    value.set('b');
+    expect(ref.get()).toHaveLength(1);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('B');
+
+    value.set('a');
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('A');
   });
 };
 

--- a/tests/fragment-refs/unique-refs.spec.tsx
+++ b/tests/fragment-refs/unique-refs.spec.tsx
@@ -1,22 +1,22 @@
-import {
-  Await,
-  Cell,
-  For,
-  Fragment,
-  If,
-  Switch,
-  createUnique,
-  getActiveRenderer,
-} from 'retend';
+import { Cell, Fragment, If, createUnique, getActiveRenderer } from 'retend';
 import { describe, expect, it } from 'vitest';
 
 import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
 
 const runTests = () => {
-  it('should expose the content of a unique component inside a fragment', () => {
+  it('should update the enclosing fragment ref when an If inside a Unique switches', () => {
     const renderer = getActiveRenderer();
     const ref = Cell.source<HTMLElement[] | null>(null);
-    const UniqueContent = createUnique(() => <div>unique</div>);
+    const condition = Cell.source(true);
+
+    const UniqueContent = createUnique(() => {
+      return If(
+        condition,
+        () => <div>yes</div>,
+        () => <span>no</span>
+      );
+    });
+
     const App = () => (
       <Fragment ref={ref}>
         <UniqueContent />
@@ -24,283 +24,313 @@ const runTests = () => {
     );
 
     renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
-    expect(textOf(nodes![0] as NodeLike)).toBe('unique');
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('no');
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
   });
 
-  it('should keep unique siblings with distinct ids in document order', () => {
+  it('should empty the enclosing fragment ref when an If inside a Unique turns falsy without an else branch', () => {
     const renderer = getActiveRenderer();
     const ref = Cell.source<HTMLElement[] | null>(null);
-    const UniqueContent = createUnique((props: Cell<{ label: string }>) => (
-      <div>{props.get().label}</div>
-    ));
+    const condition = Cell.source(true);
+
+    const UniqueContent = createUnique(() => {
+      return If(condition, () => <div>yes</div>);
+    });
+
     const App = () => (
       <Fragment ref={ref}>
-        <UniqueContent id="a" label="A" />
-        <UniqueContent id="b" label="B" />
+        <UniqueContent />
       </Fragment>
     );
 
     renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['A', 'B']);
-    for (const node of nodes!) {
-      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
-    }
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
+
+    condition.set(false);
+    expect(ref.get()).toEqual([]);
+
+    condition.set(true);
+    expect(textOf(ref.get()![0] as NodeLike)).toBe('yes');
   });
 
-  it('should expose the active branch of an If inside a unique component', () => {
+  it('should expose a Unique moved between two fragments in each ref', () => {
     const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(false);
+
+    const UniqueContent = createUnique(() => <div>Unique Data</div>);
+
+    const App = () => (
+      <>
+        <Fragment ref={refFirst}>
+          {If(
+            showSecond,
+            () => null,
+            () => (
+              <UniqueContent />
+            )
+          )}
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(refFirst.get()![0] as NodeLike)).toBe('Unique Data');
+    expect(refSecond.get()).toEqual([]);
+
+    showSecond.set(true);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('Unique Data');
+    expect(refFirst.get()).toEqual([]);
+  });
+
+  it('should empty the previous ref when a Unique moves out of a static fragment', () => {
+    const renderer = getActiveRenderer();
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(true);
+
+    const UniqueContent = createUnique(() => <div>Unique Data</div>);
+
+    const App = () => (
+      <>
+        <Fragment ref={refFirst}>
+          <UniqueContent />
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('Unique Data');
+    expect(refFirst.get()).toEqual([]);
+  });
+
+  it('should restore the fragment ref when the latest unique instance is removed', () => {
+    const renderer = getActiveRenderer();
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(true);
+
+    const UniqueContent = createUnique(() => <div>Unique Data</div>);
+
+    const App = () => (
+      <>
+        <Fragment ref={refFirst}>
+          {If(
+            showSecond,
+            () => null,
+            () => (
+              <UniqueContent />
+            )
+          )}
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('Unique Data');
+    expect(refFirst.get()).toEqual([]);
+
+    showSecond.set(false);
+    expect(textOf(refFirst.get()![0] as NodeLike)).toBe('Unique Data');
+    expect(refSecond.get()).toEqual([]);
+  });
+
+  it('should keep an If inside a Unique reactive after the Unique moves between locations', () => {
+    const renderer = getActiveRenderer();
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(false);
     const condition = Cell.source(true);
-    const UniqueContent = createUnique(() =>
-      If(
+
+    const UniqueContent = createUnique(() => {
+      return If(
         condition,
         () => <div>yes</div>,
-        () => <div>no</div>
-      )
-    );
+        () => <span>no</span>
+      );
+    });
+
     const App = () => (
-      <Fragment ref={ref}>
-        <UniqueContent id="x" />
-      </Fragment>
+      <>
+        <Fragment ref={refFirst}>
+          {If(
+            showSecond,
+            () => null,
+            () => (
+              <UniqueContent />
+            )
+          )}
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
+        </Fragment>
+      </>
     );
 
     renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
-    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+    expect(textOf(refFirst.get()![0] as NodeLike)).toBe('yes');
+
+    showSecond.set(true);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('yes');
+    expect(refFirst.get()).toEqual([]);
+
+    condition.set(false);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('no');
+    expect(refFirst.get()).toEqual([]);
+
+    condition.set(true);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('yes');
   });
 
-  it('should expose the mapped items of a For inside a unique component', () => {
+  it('should propagate a nested ref change to the current enclosing fragment after a move', () => {
     const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const items = Cell.source(['a', 'b', 'c']);
-    const UniqueContent = createUnique(() =>
-      For(items, (item) => <li>{item}</li>)
-    );
-    const App = () => (
-      <Fragment ref={ref}>
-        <UniqueContent id="x" />
-      </Fragment>
-    );
-
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
-      'a',
-      'b',
-      'c',
-    ]);
-    for (const node of nodes!) {
-      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
-    }
-  });
-
-  it('should expose a unique component rendered inside an If branch', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const innerRef = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(false);
     const condition = Cell.source(true);
-    const UniqueContent = createUnique(() => <div>U</div>);
-    const App = () => (
-      <Fragment ref={ref}>
-        {If(condition, () => (
-          <UniqueContent id="x" />
-        ))}
-      </Fragment>
-    );
 
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
-    expect(textOf(nodes![0] as NodeLike)).toBe('U');
-  });
+    const UniqueContent = createUnique(() => {
+      return (
+        <Fragment ref={innerRef}>
+          {If(
+            condition,
+            () => (
+              <div>yes</div>
+            ),
+            () => (
+              <span>no</span>
+            )
+          )}
+        </Fragment>
+      );
+    });
 
-  it('should collect multiple nodes when a unique component returns a fragment', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const UniqueContent = createUnique(() => (
-      <>
-        <span>1</span>
-        <span>2</span>
-      </>
-    ));
-    const App = () => (
-      <Fragment ref={ref}>
-        <UniqueContent id="x" />
-      </Fragment>
-    );
-
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['1', '2']);
-    for (const node of nodes!) {
-      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
-    }
-  });
-
-  it('should re-expose the unique content when the parent re-renders', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const UniqueContent = createUnique(() => <div>U</div>);
-    const App = () => (
-      <Fragment ref={ref}>
-        <UniqueContent id="x" />
-      </Fragment>
-    );
-
-    renderer.render(<App />);
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
-    expect(textOf(nodes![0] as NodeLike)).toBe('U');
-  });
-
-  it('should not duplicate the content when the same unique id renders twice', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const UniqueContent = createUnique(() => <div>U</div>);
-    const App = () => (
-      <Fragment ref={ref}>
-        <UniqueContent id="x" />
-        <UniqueContent id="x" />
-      </Fragment>
-    );
-
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
-    expect(textOf(nodes![0] as NodeLike)).toBe('U');
-  });
-
-  it('should track an If created inside Unique before the Unique enters a fragment', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const condition = Cell.source(true);
-    const UniqueContent = createUnique(() =>
-      If(
-        condition,
-        () => <div>yes</div>,
-        () => <div>no</div>
-      )
-    );
     const App = () => (
       <>
-        <UniqueContent id="x" />
-        <Fragment ref={ref}>
-          <UniqueContent id="x" />
+        <Fragment ref={refFirst}>
+          {If(
+            showSecond,
+            () => null,
+            () => (
+              <UniqueContent />
+            )
+          )}
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
         </Fragment>
       </>
     );
 
     renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+    expect(textOf(refFirst.get()![0] as NodeLike)).toBe('yes');
+    expect(refSecond.get()).toEqual([]);
+
+    showSecond.set(true);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('yes');
+    expect(refFirst.get()).toEqual([]);
+
+    condition.set(false);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('no');
+    expect(refFirst.get()).toEqual([]);
+    expect(textOf(innerRef.get()![0] as NodeLike)).toBe('no');
   });
 
-  it('should track a For created inside Unique before the Unique enters a fragment', () => {
+  it('should keep listeners and derived cells inside a Unique alive after a move', () => {
     const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const items = Cell.source(['a', 'b']);
-    const UniqueContent = createUnique(() =>
-      For(items, (item) => <li>{item}</li>)
-    );
+    const refFirst = Cell.source<HTMLElement[] | null>(null);
+    const refSecond = Cell.source<HTMLElement[] | null>(null);
+    const showSecond = Cell.source(false);
+    const count = Cell.source(1);
+    let listenerCalls = 0;
+
+    const UniqueContent = createUnique(() => {
+      count.listen(() => {
+        listenerCalls += 1;
+      });
+      const doubled = Cell.derived(() => count.get() * 2);
+      return <div>{doubled}</div>;
+    });
+
     const App = () => (
       <>
-        <UniqueContent id="x" />
-        <Fragment ref={ref}>
-          <UniqueContent id="x" />
+        <Fragment ref={refFirst}>
+          {If(
+            showSecond,
+            () => null,
+            () => (
+              <UniqueContent />
+            )
+          )}
+        </Fragment>
+        <Fragment ref={refSecond}>
+          {If(
+            showSecond,
+            () => (
+              <UniqueContent />
+            ),
+            () => null
+          )}
         </Fragment>
       </>
     );
 
     renderer.render(<App />);
-    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
-      'a',
-      'b',
-    ]);
-  });
+    expect(textOf(refFirst.get()![0] as NodeLike)).toBe('2');
 
-  it('should track a Switch created inside Unique before the Unique enters a fragment', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const value = Cell.source<'a' | 'b'>('b');
-    const UniqueContent = createUnique(() =>
-      Switch(value, {
-        a: () => <b>A</b>,
-        b: () => <i>B</i>,
-      })
-    );
-    const App = () => (
-      <>
-        <UniqueContent id="x" />
-        <Fragment ref={ref}>
-          <UniqueContent id="x" />
-        </Fragment>
-      </>
-    );
+    showSecond.set(true);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('2');
+    expect(refFirst.get()).toEqual([]);
 
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(textOf(nodes![0] as NodeLike)).toBe('B');
-  });
-
-  it('should track an Await fallback created inside Unique before the Unique enters a fragment', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const pending = Cell.derivedAsync(
-      () => new Promise<string>(() => undefined)
-    );
-    const UniqueContent = createUnique(() => (
-      <Await fallback={<span>Loading</span>}>
-        <div>{pending}</div>
-      </Await>
-    ));
-    const App = () => (
-      <>
-        <UniqueContent id="x" />
-        <Fragment ref={ref}>
-          <UniqueContent id="x" />
-        </Fragment>
-      </>
-    );
-
-    renderer.render(<App />);
-    const nodes = ref.get();
-    expect(nodes).toHaveLength(1);
-    expect(textOf(nodes![0] as NodeLike)).toBe('Loading');
-  });
-
-  it('should track nested reactive groups created inside Unique before it enters a fragment', () => {
-    const renderer = getActiveRenderer();
-    const ref = Cell.source<HTMLElement[] | null>(null);
-    const visible = Cell.source(true);
-    const items = Cell.source(['a', 'b']);
-    const UniqueContent = createUnique(() =>
-      If(visible, () => For(items, (item) => <li>{item}</li>))
-    );
-    const App = () => (
-      <>
-        <UniqueContent id="x" />
-        <Fragment ref={ref}>
-          <UniqueContent id="x" />
-        </Fragment>
-      </>
-    );
-
-    renderer.render(<App />);
-    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
-      'a',
-      'b',
-    ]);
+    count.set(3);
+    expect(listenerCalls).toBe(1);
+    expect(textOf(refSecond.get()![0] as NodeLike)).toBe('6');
   });
 };
 

--- a/tests/fragment-refs/unique-refs.spec.tsx
+++ b/tests/fragment-refs/unique-refs.spec.tsx
@@ -1,0 +1,317 @@
+import {
+  Await,
+  Cell,
+  For,
+  Fragment,
+  If,
+  Switch,
+  createUnique,
+  getActiveRenderer,
+} from 'retend';
+import { describe, expect, it } from 'vitest';
+
+import { browserSetup, textOf, vDomSetup, type NodeLike } from '../setup.tsx';
+
+const runTests = () => {
+  it('should expose the content of a unique component inside a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const UniqueContent = createUnique(() => <div>unique</div>);
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('unique');
+  });
+
+  it('should keep unique siblings with distinct ids in document order', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const UniqueContent = createUnique((props: Cell<{ label: string }>) => (
+      <div>{props.get().label}</div>
+    ));
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="a" label="A" />
+        <UniqueContent id="b" label="B" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['A', 'B']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should expose the active branch of an If inside a unique component', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const UniqueContent = createUnique(() =>
+      If(
+        condition,
+        () => <div>yes</div>,
+        () => <div>no</div>
+      )
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="x" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should expose the mapped items of a For inside a unique component', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source(['a', 'b', 'c']);
+    const UniqueContent = createUnique(() =>
+      For(items, (item) => <li>{item}</li>)
+    );
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="x" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should expose a unique component rendered inside an If branch', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const UniqueContent = createUnique(() => <div>U</div>);
+    const App = () => (
+      <Fragment ref={ref}>
+        {If(condition, () => (
+          <UniqueContent id="x" />
+        ))}
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('U');
+  });
+
+  it('should collect multiple nodes when a unique component returns a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const UniqueContent = createUnique(() => (
+      <>
+        <span>1</span>
+        <span>2</span>
+      </>
+    ));
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="x" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes!.map((node) => textOf(node as NodeLike))).toEqual(['1', '2']);
+    for (const node of nodes!) {
+      expect(node).toBeInstanceOf(renderer.host.HTMLElement);
+    }
+  });
+
+  it('should re-expose the unique content when the parent re-renders', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const UniqueContent = createUnique(() => <div>U</div>);
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="x" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('U');
+  });
+
+  it('should not duplicate the content when the same unique id renders twice', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const UniqueContent = createUnique(() => <div>U</div>);
+    const App = () => (
+      <Fragment ref={ref}>
+        <UniqueContent id="x" />
+        <UniqueContent id="x" />
+      </Fragment>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(nodes![0]).toBeInstanceOf(renderer.host.HTMLElement);
+    expect(textOf(nodes![0] as NodeLike)).toBe('U');
+  });
+
+  it('should track an If created inside Unique before the Unique enters a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const condition = Cell.source(true);
+    const UniqueContent = createUnique(() =>
+      If(
+        condition,
+        () => <div>yes</div>,
+        () => <div>no</div>
+      )
+    );
+    const App = () => (
+      <>
+        <UniqueContent id="x" />
+        <Fragment ref={ref}>
+          <UniqueContent id="x" />
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('yes');
+  });
+
+  it('should track a For created inside Unique before the Unique enters a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const items = Cell.source(['a', 'b']);
+    const UniqueContent = createUnique(() =>
+      For(items, (item) => <li>{item}</li>)
+    );
+    const App = () => (
+      <>
+        <UniqueContent id="x" />
+        <Fragment ref={ref}>
+          <UniqueContent id="x" />
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('should track a Switch created inside Unique before the Unique enters a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const value = Cell.source<'a' | 'b'>('b');
+    const UniqueContent = createUnique(() =>
+      Switch(value, {
+        a: () => <b>A</b>,
+        b: () => <i>B</i>,
+      })
+    );
+    const App = () => (
+      <>
+        <UniqueContent id="x" />
+        <Fragment ref={ref}>
+          <UniqueContent id="x" />
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('B');
+  });
+
+  it('should track an Await fallback created inside Unique before the Unique enters a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const pending = Cell.derivedAsync(
+      () => new Promise<string>(() => undefined)
+    );
+    const UniqueContent = createUnique(() => (
+      <Await fallback={<span>Loading</span>}>
+        <div>{pending}</div>
+      </Await>
+    ));
+    const App = () => (
+      <>
+        <UniqueContent id="x" />
+        <Fragment ref={ref}>
+          <UniqueContent id="x" />
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    const nodes = ref.get();
+    expect(nodes).toHaveLength(1);
+    expect(textOf(nodes![0] as NodeLike)).toBe('Loading');
+  });
+
+  it('should track nested reactive groups created inside Unique before it enters a fragment', () => {
+    const renderer = getActiveRenderer();
+    const ref = Cell.source<HTMLElement[] | null>(null);
+    const visible = Cell.source(true);
+    const items = Cell.source(['a', 'b']);
+    const UniqueContent = createUnique(() =>
+      If(visible, () => For(items, (item) => <li>{item}</li>))
+    );
+    const App = () => (
+      <>
+        <UniqueContent id="x" />
+        <Fragment ref={ref}>
+          <UniqueContent id="x" />
+        </Fragment>
+      </>
+    );
+
+    renderer.render(<App />);
+    expect(ref.get()!.map((node) => textOf(node as NodeLike))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+};
+
+describe('Unique Block Fragment Refs', () => {
+  describe('Browser', () => {
+    browserSetup();
+    runTests();
+  });
+
+  describe('VDom', () => {
+    vDomSetup();
+    runTests();
+  });
+});

--- a/tests/observer.spec.tsx
+++ b/tests/observer.spec.tsx
@@ -15,9 +15,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { browserSetup, timeout } from './setup.tsx';
 
 const activateEffects = async () => {
-  const node = getState().node;
-  node.enable();
-  await node.activate();
+  await getState().node.activate();
 };
 
 describe('onConnected', () => {
@@ -477,7 +475,9 @@ describe('onConnected', () => {
     const connected: number[] = [];
     const Item = (item: number) => {
       const ref = Cell.source<HTMLElement | null>(null);
-      onConnected(ref, () => connected.push(item));
+      onConnected(ref, () => {
+        connected.push(item);
+      });
       return <span ref={ref}>{item}</span>;
     };
 

--- a/tests/scope/on-setup/await.spec.tsx
+++ b/tests/scope/on-setup/await.spec.tsx
@@ -51,6 +51,66 @@ describe('onSetup with Await', () => {
     expect(setupFn).toHaveBeenCalledTimes(1);
   });
 
+  it('activates setup only after all content is committed', async () => {
+    const setupFn = vi.fn();
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    let contentWhenSetupRan: string | null = null;
+    let result!: HTMLElement;
+
+    const first = Cell.derivedAsync(async () => {
+      await new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      return 'First';
+    });
+    const second = Cell.derivedAsync(async () => {
+      await new Promise<void>((resolve) => {
+        resolveSecond = resolve;
+      });
+      return 'Second';
+    });
+    const Child = () => {
+      onSetup(() => {
+        contentWhenSetupRan = getTextContent(result);
+        setupFn();
+      });
+      return (
+        <span>
+          {first} {second}
+        </span>
+      );
+    };
+    const App = () => (
+      <div>
+        <Await fallback={<span>Loading</span>}>
+          <Child />
+        </Await>
+      </div>
+    );
+
+    const renderer = getActiveRenderer();
+    result = renderer.render(App) as HTMLElement;
+    window.document.body.append(result);
+    await runPendingSetupEffects();
+
+    expect(getTextContent(result)).toBe('Loading');
+    expect(setupFn).not.toHaveBeenCalled();
+
+    resolveFirst();
+    await timeout();
+    expect(getTextContent(result)).toBe('Loading');
+    expect(setupFn).not.toHaveBeenCalled();
+
+    resolveSecond();
+    await timeout();
+    await timeout();
+
+    expect(getTextContent(result)).toBe('First Second');
+    expect(setupFn).toHaveBeenCalledTimes(1);
+    expect(contentWhenSetupRan).toBe('First Second');
+  });
+
   it('registers cleanup only after Await resolves', async () => {
     const cleanupFn = vi.fn();
     const setupFn = vi.fn(() => cleanupFn);

--- a/tests/scope/on-setup/lifecycle.spec.tsx
+++ b/tests/scope/on-setup/lifecycle.spec.tsx
@@ -1,0 +1,77 @@
+import {
+  branchState,
+  onSetup,
+  runPendingSetupEffects,
+  withState,
+} from 'retend';
+import { describe, expect, it, vi } from 'vitest';
+
+import { browserSetup } from '../../setup.tsx';
+
+describe('effect lifecycle modes', () => {
+  browserSetup();
+
+  it('activates deferred branches only when called directly', async () => {
+    const cleanupFn = vi.fn();
+    const setupFn = vi.fn(() => cleanupFn);
+    const snapshot = branchState('deferred');
+
+    withState(snapshot, () => onSetup(setupFn));
+    await runPendingSetupEffects();
+    expect(setupFn).not.toHaveBeenCalled();
+
+    await snapshot.node.activate();
+    await snapshot.node.activate();
+
+    expect(setupFn).toHaveBeenCalledTimes(1);
+    expect(cleanupFn).not.toHaveBeenCalled();
+
+    snapshot.node.dispose();
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reactivate descendants after an ancestor disposes them', async () => {
+    const setupFn = vi.fn();
+    const parent = branchState();
+    const child = withState(parent, () => branchState());
+
+    withState(child, () => onSetup(setupFn));
+    parent.node.dispose();
+    await child.node.activate();
+
+    expect(setupFn).not.toHaveBeenCalled();
+  });
+
+  it('allows directly disposed branches to activate new setup effects', async () => {
+    const firstSetup = vi.fn();
+    const secondSetup = vi.fn();
+    const snapshot = branchState();
+
+    withState(snapshot, () => onSetup(firstSetup));
+    await runPendingSetupEffects();
+    expect(firstSetup).toHaveBeenCalledTimes(1);
+
+    snapshot.node.dispose();
+    withState(snapshot, () => onSetup(secondSetup));
+    await snapshot.node.activate();
+
+    expect(firstSetup).toHaveBeenCalledTimes(1);
+    expect(secondSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it('only disposes retained branches when called directly', async () => {
+    const cleanupFn = vi.fn();
+    const parent = branchState();
+    const retained = withState(parent, () => branchState('retained'));
+
+    withState(retained, () => onSetup(() => cleanupFn));
+    await runPendingSetupEffects();
+    expect(cleanupFn).not.toHaveBeenCalled();
+
+    parent.node.dispose();
+    expect(cleanupFn).not.toHaveBeenCalled();
+
+    retained.node.dispose();
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/setup.tsx
+++ b/tests/setup.tsx
@@ -99,3 +99,15 @@ export const getTextContent = (element: Node | VNode) => {
 
   return text;
 };
+
+/**
+ * Reads the text of a single leaf node (element or text node) from the ref,
+ * dispatching to the right read path for the current renderer.
+ */
+export const textOf = (node: NodeLike): string | null => {
+  const { host: window } = getActiveRenderer() as DOMRenderer;
+  if (node.nodeType === window.Node.TEXT_NODE) {
+    return node.textContent;
+  }
+  return getTextContent(node);
+};

--- a/tests/test.md
+++ b/tests/test.md
@@ -1,0 +1,15 @@
+Given this, will this patten work:
+
+```tsx
+const MyWrapperComponent = (props: MyWrapperProps) => {
+  const { children } = props;
+  const ref = Cell.source<HTMLElement[]>(null);
+  const firstElementRef = Cell.derived(() => ref.get()?.[0]);
+
+  onConnected(firstElementRef, (el) => {
+    console.log('The first element in the fragment is ', el);
+  });
+
+  return <Fragment ref={ref}>{children}</Fragment>;
+};
+```

--- a/tests/unique.spec.tsx
+++ b/tests/unique.spec.tsx
@@ -328,6 +328,104 @@ describe('Unique', () => {
       body.replaceChildren();
     });
 
+    it('should skip a removed middle Unique handle when restoring', async () => {
+      const renderer = getActiveRenderer() as DOMRenderer;
+      const { host: window } = renderer;
+      const uuid = crypto.randomUUID();
+      const showSecond = Cell.source(true);
+      const showThird = Cell.source(true);
+
+      const UniqueContent = createUnique(() => <div>Unique Data</div>);
+
+      const { body } = window.document;
+      body.append(
+        render(
+          <div>
+            <div class="first">
+              <UniqueContent id={uuid} />
+            </div>
+            <div class="second">
+              {If(showSecond, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+            <div class="third">
+              {If(showThird, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+          </div>
+        )
+      );
+      await runPendingSetupEffects();
+
+      expect(getTextContent(body.querySelector('.third')!)).toBe('Unique Data');
+
+      showThird.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.second')!)).toBe(
+        'Unique Data'
+      );
+
+      showThird.set(true);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.third')!)).toBe('Unique Data');
+
+      showSecond.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.third')!)).toBe('Unique Data');
+
+      showThird.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.first')!)).toBe('Unique Data');
+
+      body.replaceChildren();
+    });
+
+    it('should skip a removed middle Unique handle when the latest handle is removed in the same update', async () => {
+      const renderer = getActiveRenderer() as DOMRenderer;
+      const { host: window } = renderer;
+      const uuid = crypto.randomUUID();
+      const showSecond = Cell.source(true);
+      const showThird = Cell.source(true);
+
+      const UniqueContent = createUnique(() => <div>Unique Data</div>);
+
+      const { body } = window.document;
+      body.append(
+        render(
+          <div>
+            <div class="first">
+              <UniqueContent id={uuid} />
+            </div>
+            <div class="second">
+              {If(showSecond, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+            <div class="third">
+              {If(showThird, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+          </div>
+        )
+      );
+      await runPendingSetupEffects();
+
+      expect(getTextContent(body.querySelector('.third')!)).toBe('Unique Data');
+
+      showSecond.set(false);
+      showThird.set(false);
+      await runPendingSetupEffects();
+
+      expect(getTextContent(body.querySelector('.first')!)).toBe('Unique Data');
+      expect(getTextContent(body.querySelector('.second')!)).toBe('');
+      expect(getTextContent(body.querySelector('.third')!)).toBe('');
+
+      body.replaceChildren();
+    });
+
     it('should move a Unique component that returns multiple elements', async () => {
       const renderer = getActiveRenderer() as DOMRenderer;
       const { host: window } = renderer;

--- a/tests/unique.spec.tsx
+++ b/tests/unique.spec.tsx
@@ -5,11 +5,13 @@ import {
   Cell,
   If,
   Switch,
+  createScope,
   createUnique,
   getActiveRenderer,
   onMove,
   onSetup,
   runPendingSetupEffects,
+  useScopeContext,
 } from 'retend';
 import { UniqueTransition } from 'retend-utils/components';
 import { ShadowRoot } from 'retend-web';
@@ -1123,6 +1125,158 @@ describe('Unique', () => {
       expect(getTextContent(body)).toBe('');
       expect(setupFn).toHaveBeenCalledTimes(1); // isn't called again.
       expect(cleanupFn).toHaveBeenCalledTimes(1); // is called!
+      body.replaceChildren();
+    });
+
+    it('should still run new setup fns inside of Unique components after move', async () => {
+      const renderer = getActiveRenderer() as DOMRenderer;
+      const { host: window } = renderer;
+      const uuid = crypto.randomUUID();
+      const showFirst = Cell.source(true);
+      const showSecond = Cell.source(false);
+      const showChild = Cell.source(false);
+      const childSetup = vi.fn();
+      const childCleanup = vi.fn();
+
+      const Child = () => {
+        onSetup(() => {
+          childSetup();
+          return childCleanup;
+        });
+        return <span>Child</span>;
+      };
+      const UniqueContent = createUnique(() => (
+        <div>{If(showChild, Child)}</div>
+      ));
+
+      const { body } = window.document;
+      body.append(
+        render(
+          <div>
+            <div class="first">
+              {If(showFirst, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+            <div class="second">
+              {If(showSecond, () => (
+                <UniqueContent id={uuid} />
+              ))}
+            </div>
+          </div>
+        )
+      );
+      await runPendingSetupEffects();
+
+      expect(childSetup).not.toHaveBeenCalled();
+
+      showSecond.set(true);
+      showFirst.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.first')!)).toBe('');
+      expect(getTextContent(body.querySelector('.second')!)).toBe('');
+
+      showChild.set(true);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.second')!)).toBe('Child');
+      expect(childSetup).toHaveBeenCalledTimes(1);
+      expect(childCleanup).not.toHaveBeenCalled();
+
+      showChild.set(false);
+      await runPendingSetupEffects();
+      expect(childCleanup).toHaveBeenCalledTimes(1);
+
+      showChild.set(true);
+      await runPendingSetupEffects();
+      expect(childSetup).toHaveBeenCalledTimes(2);
+      expect(childCleanup).toHaveBeenCalledTimes(1);
+      body.replaceChildren();
+    });
+
+    it('should not disturb nested scopes and effects inside children of Unique components during move', async () => {
+      const renderer = getActiveRenderer() as DOMRenderer;
+      const { host: window } = renderer;
+      const uuid = crypto.randomUUID();
+      const value = Cell.source(0);
+      const showApp = Cell.source(true);
+      const showFirst = Cell.source(true);
+      const showSecond = Cell.source(false);
+      const childSetup = vi.fn();
+      const childCleanup = vi.fn();
+      const valueListener = vi.fn();
+      const ValueScope = createScope<typeof value>('UniqueMoveValue');
+
+      const Child = () => {
+        const scopedValue = useScopeContext(ValueScope);
+        scopedValue.listen(valueListener);
+        onSetup(() => {
+          childSetup();
+          return childCleanup;
+        });
+        return <span>{scopedValue}</span>;
+      };
+      const UniqueContent = createUnique(() => (
+        <ValueScope.Provider value={value}>
+          <Child />
+        </ValueScope.Provider>
+      ));
+
+      const { body } = window.document;
+      body.append(
+        render(
+          <div>
+            {If(showApp, () => (
+              <>
+                <div class="first">
+                  {If(showFirst, () => (
+                    <UniqueContent id={uuid} />
+                  ))}
+                </div>
+                <div class="second">
+                  {If(showSecond, () => (
+                    <UniqueContent id={uuid} />
+                  ))}
+                </div>
+              </>
+            ))}
+          </div>
+        )
+      );
+      await runPendingSetupEffects();
+
+      expect(childSetup).toHaveBeenCalledTimes(1);
+      expect(childCleanup).not.toHaveBeenCalled();
+      expect(getTextContent(body.querySelector('.first')!)).toBe('0');
+
+      value.set(1);
+      expect(valueListener).toHaveBeenCalledTimes(1);
+
+      showSecond.set(true);
+      showFirst.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.second')!)).toBe('1');
+      expect(childSetup).toHaveBeenCalledTimes(1);
+      expect(childCleanup).not.toHaveBeenCalled();
+
+      value.set(2);
+      expect(valueListener).toHaveBeenCalledTimes(2);
+
+      showFirst.set(true);
+      showSecond.set(false);
+      await runPendingSetupEffects();
+      expect(getTextContent(body.querySelector('.first')!)).toBe('2');
+      expect(childSetup).toHaveBeenCalledTimes(1);
+      expect(childCleanup).not.toHaveBeenCalled();
+
+      value.set(3);
+      expect(valueListener).toHaveBeenCalledTimes(3);
+
+      showApp.set(false);
+      await runPendingSetupEffects();
+      expect(childCleanup).toHaveBeenCalledTimes(1);
+
+      value.set(4);
+      expect(valueListener).toHaveBeenCalledTimes(3);
       body.replaceChildren();
     });
 

--- a/tests/unique.spec.tsx
+++ b/tests/unique.spec.tsx
@@ -229,6 +229,61 @@ describe('Unique', () => {
       body.replaceChildren();
     });
 
+    it('should not run setup cleanups when a Unique moves before its old location is disposed', async () => {
+      const renderer = getActiveRenderer() as DOMRenderer;
+      const { host: window } = renderer;
+      const uuid = crypto.randomUUID();
+      const setupFn = vi.fn();
+      const cleanupFn = vi.fn();
+
+      const UniqueContent = createUnique(() => {
+        onSetup(() => {
+          setupFn();
+          return cleanupFn;
+        });
+        return <div>Unique Data</div>;
+      });
+
+      const showFirst = Cell.source(true);
+      const showSecond = Cell.source(false);
+      const { body } = window.document;
+      const element = render(
+        <div>
+          {/* `.second` first so its If listener fires before the first's */}
+          <div class="second">
+            {If(showSecond, () => (
+              <UniqueContent id={uuid} />
+            ))}
+          </div>
+          <div class="first">
+            {If(showFirst, () => (
+              <UniqueContent id={uuid} />
+            ))}
+          </div>
+        </div>
+      );
+
+      body.append(element);
+      await runPendingSetupEffects();
+      expect(setupFn).toHaveBeenCalledTimes(1);
+
+      // The second If's listener fires first, so the Unique moves to `.second`
+      // while `.first` is still mounted. The old location's dispose cascade
+      // then reaches the instance — its cleanups must not run, since the
+      // instance is moving, not dying.
+      showSecond.set(true);
+      showFirst.set(false);
+      await runPendingSetupEffects();
+
+      expect(getTextContent(body.querySelector('.first')!)).toBe('');
+      expect(getTextContent(body.querySelector('.second')!)).toBe(
+        'Unique Data'
+      );
+      expect(setupFn).toHaveBeenCalledTimes(1);
+      expect(cleanupFn).not.toHaveBeenCalled();
+      body.replaceChildren();
+    });
+
     it('should clean up onMove callbacks when a child unmounts', async () => {
       const renderer = getActiveRenderer() as DOMRenderer;
       const { host: window } = renderer;


### PR DESCRIPTION
## Summary

- add reactive ref tracking for Fragment output across If, For, Switch, Await, and Unique blocks
- preserve fragment node tracking through dynamic updates and lifecycle transitions
- document Fragment refs and add comprehensive coverage for static and dynamic children

## Testing

- pnpm run build
- pnpm run test (972 browser tests and 20 lint-plugin tests passed)